### PR TITLE
Recent files, problem with file separator in path.

### DIFF
--- a/src/main/java/nl/digitalekabeltelevisie/gui/utils/RecentFiles.java
+++ b/src/main/java/nl/digitalekabeltelevisie/gui/utils/RecentFiles.java
@@ -27,7 +27,6 @@
 
 package nl.digitalekabeltelevisie.gui.utils;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -40,7 +39,10 @@ import nl.digitalekabeltelevisie.util.PreferencesManager;
  *
  */
 public class RecentFiles {
-	
+
+	// to avoid splitting on valid character we use a more unique combination of characters
+	public static final String ENTRY_SEPARATOR = "\u001D\u0011\u001B";
+
 	private List<String> recentFiles = new ArrayList<>();
 	
 	private static int MAX_ENTRIES = 10;
@@ -63,7 +65,7 @@ public class RecentFiles {
 		
 		recentFiles.clear();
 		if(!allFiles.isEmpty()) {
-			recentFiles.addAll(Arrays.asList(allFiles.split(File.pathSeparator)));
+			recentFiles.addAll(Arrays.asList(allFiles.split(ENTRY_SEPARATOR)));
 		}
 		if(recentFiles.size()>MAX_ENTRIES) {
 			recentFiles = recentFiles.subList(0, MAX_ENTRIES);
@@ -71,7 +73,7 @@ public class RecentFiles {
 	}
 	
 	public String getString() {
-		return recentFiles.stream().collect(Collectors.joining (File.pathSeparator));
+		return recentFiles.stream().collect(Collectors.joining (ENTRY_SEPARATOR));
 	}
 	
 	public void addOrMoveToBegin(String fileName) {


### PR DESCRIPTION
I have some files that are like this:
{IP}:{PORT}.ts
e.g.
239.12.12.12:5000.ts

this is a valid filename on Linux and MacOS. Unsure about Windows. On MacOS you need to use command line (cp, mv, etc) to use `:` in filename. It shows in finder with `/` instead of `:` char.

in the recent files 239.12.12.12:5000.ts splits to 239.12.12.12 and 5000.ts.

I've changed the separator to something more unique and very doubtful that could be part of a valid name.
Not that original. Wanted to spell DVB. \u001D\u0011\u001B.

So now the recent files work for me with files using `:` in name.

The only downside is that this change would break the existing recent files list to a one line entry.