### PR TITLE
Fix millisecond padding in getPacketShortTime

### DIFF
--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/TransportStream.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/TransportStream.java
@@ -1044,20 +1044,18 @@ public class TransportStream implements TreeNode{
 		String r = null;
 
 		if(getBitRate()!=-1){ //can't calculate time  without a bitrate
+			Calendar now;
 			if(zeroTime==null){
-				final Calendar now=new GregorianCalendar();
+				now = new GregorianCalendar();
 				now.setTimeZone(java.util.TimeZone.getTimeZone("GMT"));
 				now.setTimeInMillis(0);
-				now.add(Calendar.MILLISECOND, (int)((packetNo * packetLength * 8 * 1000)/getBitRate()));
-				// return only the hours/min,secs and millisecs. Not TS recording will last days
-				r = now.get(Calendar.HOUR_OF_DAY)+"h"+now.get(Calendar.MINUTE)+"m"+now.get(Calendar.SECOND)+":"+now.get(Calendar.MILLISECOND);
-
 			}else{
-				final Calendar now=(Calendar)zeroTime.clone();
-				now.add(Calendar.MILLISECOND, (int)((packetNo * packetLength * 8 * 1000)/getBitRate()));
-
-				r = now.get(Calendar.HOUR_OF_DAY)+"h"+df2pos.format(now.get(Calendar.MINUTE))+"m"+df2pos.format(now.get(Calendar.SECOND))+":"+df3pos.format(now.get(Calendar.MILLISECOND));
+				now = (Calendar)zeroTime.clone();
 			}
+			now.add(Calendar.MILLISECOND, (int)((packetNo * packetLength * 8 * 1000)/getBitRate()));
+			// return only the hours/min,secs and millisecs. Not TS recording will last days
+			r = now.get(Calendar.HOUR_OF_DAY)+"h"+df2pos.format(now.get(Calendar.MINUTE))+"m"+df2pos.format(now.get(Calendar.SECOND))+":"+df3pos.format(now.get(Calendar.MILLISECOND));
+
 		}else{ // no bitrate
 			r = packetNo +" (packetNo)";
 		}


### PR DESCRIPTION
In BitrateView, packets with a time with millisecond count of less than 100 are displayed. Fixed this by formatting as elsewhere (ie padding to 3dp). I appreciate that, at least at some point in the past, this method was supposed to return a shortened timestamp, but to me it's still confusing to display milliseconds in this way.

Given the method name, it wasn't clear to me why one branch of the `if` uses fully padded time format and the other uses a shortened version. In the end I figured the full version was correct and so rationalised the two branches to improve reuse - please let me know if I misunderstood the intention and I can just pad the milliseconds. Or in fact if I have missed the point entirely :smile: 

Thanks for DVBInspector - it's a great tool I've used for years (and even contributed some bits about ten years ago :sweat_smile:)

![image](https://github.com/EricBerendsen/dvbinspector/assets/5390145/a568d0e2-4638-4671-9729-950da1ec5568)
