### PR TITLE
TP_extra_header is for the next frame

### DIFF
--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/TSPacket.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/TSPacket.java
@@ -327,7 +327,7 @@ public class TSPacket implements HTMLSource, TreeNode{
 			final RangeHashMap<Integer, Color> localColoring = new RangeHashMap<>();
 			//for some reason using getHTMLHexview resets color, so we use getHTMLHexviewColored with only one color.
 			localColoring.put(0, buffer.length-PAYLOAD_PACKET_LENGTH, FEC_COLOR);
-			Utils.appendHeader(s, "FEC/timestamp:", FEC_COLOR);
+			Utils.appendHeader(s, "FEC/TP_extra_header of the next frame:", FEC_COLOR);
 			s.append(getHTMLHexviewColored(buffer,PAYLOAD_PACKET_LENGTH,buffer.length-PAYLOAD_PACKET_LENGTH,localColoring)).append("</span>");
 			coloring.put(PAYLOAD_PACKET_LENGTH, buffer.length, FEC_COLOR);
 		}


### PR DESCRIPTION
Next one may be to create payload number +1 that is of type EOF. It will not have any timestamp. Genius?