### PR TITLE
Kvp node

### DIFF
--- a/src/main/java/nl/digitalekabeltelevisie/controller/KVP.java
+++ b/src/main/java/nl/digitalekabeltelevisie/controller/KVP.java
@@ -170,14 +170,6 @@ public class KVP extends DefaultMutableTreeNode{
 		this(label, value ? 1 : 0, description);
 	}
 
-	@Deprecated
-	public KVP(String html, String label) {
-        this.setHtmlLabel(html);
-		this.label = label; // text representation of the HTML string
-		this.fieldType = FIELD_TYPE.LABEL;
-	}
-
-
 
 	/**
 	 * @param label

--- a/src/main/java/nl/digitalekabeltelevisie/controller/KVP.java
+++ b/src/main/java/nl/digitalekabeltelevisie/controller/KVP.java
@@ -36,6 +36,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.swing.JMenuItem;
+import javax.swing.tree.DefaultMutableTreeNode;
 
 import nl.digitalekabeltelevisie.gui.*;
 
@@ -65,7 +66,7 @@ import nl.digitalekabeltelevisie.gui.*;
  * @author Eric Berendsen
  *
  */
-public class KVP{
+public class KVP extends DefaultMutableTreeNode{
 
 
 	public record DetailView(DetailSource detailSource, String label) {}
@@ -231,16 +232,18 @@ public class KVP{
 		return description;
 	}
 
-	public void setDescription(String description) {
+	public KVP setDescription(String description) {
 		this.description = description;
+		return this;
 	}
 
 	public String getLabel() {
 		return label;
 	}
 
-	public void setLabel(String label) {
+	public KVP setLabel(String label) {
 		this.label = label;
+		return this;
 	}
 
 	// put appends in separate String, so original label is constant and available for path
@@ -248,13 +251,6 @@ public class KVP{
 		this.labelAppend  = this.labelAppend + labelAppend;
 	}
 
-	public String getValue() {
-		return value;
-	}
-
-	public void setValue(String value) {
-		this.value = value;
-	}
 
 	@Override
 	public String toString() {
@@ -435,16 +431,18 @@ public class KVP{
 	 * @param subMenu the subMenu to set
 	 * @param owner the owner to set
 	 */
-	public void setSubMenuAndOwner(JMenuItem subMenu, Object owner) {
+	public KVP setSubMenuAndOwner(JMenuItem subMenu, Object owner) {
 		this.subMenu = subMenu;
 		this.owner = owner;
+		return this;
 	}
 
 	/**
 	 * @param subMenu the subMenu to set
 	 */
-	public void setSubMenu(JMenuItem subMenu) {
+	public KVP setSubMenu(JMenuItem subMenu) {
 		this.subMenu = subMenu;
+		return this;
 	}
 
 	/**
@@ -485,28 +483,40 @@ public class KVP{
 	
 	
 
-	public void setCrumb(String path) {
+	public KVP setCrumb(String path) {
 		this.crumb = path;
+		return this;
 	}
 
 	public List<DetailView> getDetailViews() {
 		return detailViews;
 	}
 	
-	public void addHTMLSource(HTMLSource htmlSource, String label) {
+	public KVP addHTMLSource(HTMLSource htmlSource, String label) {
 		detailViews.add(new DetailView(htmlSource, label));
+		return this;
 	}
 
-	public void addImageSource(ImageSource imageSource, String label) {
+	public KVP addImageSource(ImageSource imageSource, String label) {
 		detailViews.add(new DetailView(imageSource, label));
+		return this;
 	}
 
-	public void addTableSource(TableSource tableSource, String label) {
+	public KVP addTableSource(TableSource tableSource, String label) {
 		detailViews.add(new DetailView(tableSource, label));
+		return this;
 	}
 
-	public void addXMLSource(XMLSource xmlSource, String label) {
+	public KVP addXMLSource(XMLSource xmlSource, String label) {
 		detailViews.add(new DetailView(xmlSource, label));
+		return this;
 	}
 
+	@Override
+    public Object getUserObject() {
+        return this;
+    }
+
+
+	
 }

--- a/src/main/java/nl/digitalekabeltelevisie/controller/KVP.java
+++ b/src/main/java/nl/digitalekabeltelevisie/controller/KVP.java
@@ -206,6 +206,8 @@ public class KVP extends DefaultMutableTreeNode{
         this.label = label;
 		this.dvbStringValue = dvbStringValue;
 		this.fieldType = FIELD_TYPE.DVBSTRING;
+		this.add(new KVP("encoding", dvbStringValue.getEncodingString()));
+		this.add(new KVP("length", dvbStringValue.getLength()));
 	}
 
 	public KVP(String label, DVBString dvbStringValue, String description) {

--- a/src/main/java/nl/digitalekabeltelevisie/controller/KVP.java
+++ b/src/main/java/nl/digitalekabeltelevisie/controller/KVP.java
@@ -92,7 +92,6 @@ public class KVP extends DefaultMutableTreeNode{
 
 		LABEL, //used for a node that has no value associated with it
 		DVBSTRING,
-		HTML, // used for a node that has no separate value associated with , but a HTML fragment as value  for presentation where possible, has to have a plain text alternative
 
 		BIGINT
 	}
@@ -133,6 +132,7 @@ public class KVP extends DefaultMutableTreeNode{
 	private JMenuItem subMenu;
 	private Object owner;
 	private String labelAppend = "";
+	private String htmlLabel;
 
 	public KVP(String label) {
         this.label = label;
@@ -151,6 +151,7 @@ public class KVP extends DefaultMutableTreeNode{
 		}
 	}
 
+	
 	public KVP(String label, int value, String description) {
         this.label = label;
 		this.intValue = value;
@@ -169,10 +170,11 @@ public class KVP extends DefaultMutableTreeNode{
 		this(label, value ? 1 : 0, description);
 	}
 
+	@Deprecated
 	public KVP(String html, String label) {
-        this.value = html;
+        this.setHtmlLabel(html);
 		this.label = label; // text representation of the HTML string
-		this.fieldType = FIELD_TYPE.HTML;
+		this.fieldType = FIELD_TYPE.LABEL;
 	}
 
 
@@ -247,32 +249,28 @@ public class KVP extends DefaultMutableTreeNode{
 	}
 
 	public String toString(STRING_DISPLAY stringFormat, NUMBER_DISPLAY numberFormat) {
-		StringBuilder b = new StringBuilder(label);
+		StringBuilder b = new StringBuilder();
+		if ((htmlLabel != null) && (STRING_DISPLAY.PLAIN != stringFormat)) {
+			b.append(htmlLabel);
+		} else {
+			b.append(label);
+		}
 		if(!labelAppend.isEmpty()) {
 			b.append(labelAppend);
 		}
 
-		if ((fieldType != FIELD_TYPE.LABEL)&&(fieldType != FIELD_TYPE.HTML)) {
+		if (fieldType != FIELD_TYPE.LABEL) {
 			appendValueAfterLabel(numberFormat, b);
 		}
-		if((fieldType==FIELD_TYPE.HTML)&&(STRING_DISPLAY.PLAIN!=stringFormat)){
-			b = replacePlainLabelWithHTML(stringFormat);
-		}
 		if (stringFormat == STRING_DISPLAY.JAVASCRIPT) {
-			return  b.toString().replace("\"", "\\\"").replace("\'", "\\\'");
+			return b.toString().replace("\"", "\\\"").replace("\'", "\\\'");
+		}
+		if ((htmlLabel != null) && (stringFormat == STRING_DISPLAY.HTML_AWT)) {
+			return new StringBuilder("<html>").append(b).append("</html>").toString();
 		}
 		return b.toString();
 	}
 
-
-	private StringBuilder replacePlainLabelWithHTML(STRING_DISPLAY stringFormat) {
-		if(stringFormat==STRING_DISPLAY.HTML_AWT){
-			return new StringBuilder("<html>").append(value).append("</html>");
-		}else if(stringFormat==STRING_DISPLAY.HTML_FRAGMENTS){
-			return new StringBuilder(value);
-		}
-		return new StringBuilder();
-	}
 
 	/**
 	 * @param numberFormat
@@ -505,6 +503,11 @@ public class KVP extends DefaultMutableTreeNode{
     public Object getUserObject() {
         return this;
     }
+
+	public KVP setHtmlLabel(String htmlLabel) {
+		this.htmlLabel = htmlLabel;
+		return this;
+	}
 
 
 	

--- a/src/main/java/nl/digitalekabeltelevisie/controller/KVP.java
+++ b/src/main/java/nl/digitalekabeltelevisie/controller/KVP.java
@@ -180,7 +180,7 @@ public class KVP extends DefaultMutableTreeNode{
 		this.byteStart = 0;
 		this.byteLen = byteArray.length;
 		this.fieldType = FIELD_TYPE.BYTES;
-		detailViews.add(new DetailView((HTMLSource) () -> getHTMLHexview(byteValue, byteStart, byteLen), "Hex View"));
+		addHTMLSource(() -> getHTMLHexview(byteValue, byteStart, byteLen), "Hex View");
 	}
 
 	public KVP(String label, byte[] byteArray, String description) {
@@ -194,7 +194,7 @@ public class KVP extends DefaultMutableTreeNode{
 		this.byteStart = offset;
 		this.byteLen = len;
 		this.fieldType = FIELD_TYPE.BYTES;
-		detailViews.add(new DetailView((HTMLSource) () -> getHTMLHexview(byteValue, byteStart, byteLen), "Hex View"));
+		addHTMLSource(() -> getHTMLHexview(byteValue, byteStart, byteLen), "Hex View");
 	}
 
 	public KVP(String label, byte[] byteArray, int offset, int len, String description) {
@@ -208,11 +208,11 @@ public class KVP extends DefaultMutableTreeNode{
 		this.fieldType = FIELD_TYPE.DVBSTRING;
 		this.add(new KVP("encoding", dvbStringValue.getEncodingString()));
 		this.add(new KVP("length", dvbStringValue.getLength()));
-	}
-
-	public KVP(String label, DVBString dvbStringValue, String description) {
-        this(label,dvbStringValue);
-		setDescription(description);
+		this.addHTMLSource(
+				() ->"<b>Encoding:</b> " + dvbStringValue.getEncodingString() 
+						+ "<br><br><b>Data:</b><br>" + getHTMLHexview(dvbStringValue.getData(), dvbStringValue.getOffset() + 1, dvbStringValue.getLength())
+						+ "<br><b>Formatted:</b><br>" + dvbStringValue.toEscapedHTML(),
+				"DVB String");
 	}
 
 	

--- a/src/main/java/nl/digitalekabeltelevisie/controller/KVP.java
+++ b/src/main/java/nl/digitalekabeltelevisie/controller/KVP.java
@@ -101,7 +101,7 @@ public class KVP extends DefaultMutableTreeNode{
 	 */
 	private static final int BYTE_DATA_MAX_LEN = 100;
 	private String		label;
-	private String		value;
+	private String		stringValue;
 	private String		description;
 
 	private int			intValue;
@@ -139,31 +139,39 @@ public class KVP extends DefaultMutableTreeNode{
 		this.fieldType = FIELD_TYPE.LABEL;
 	}
 
-	public KVP(String label, String value, String description) {
+	public KVP(String label, String stringValue) {
         this.label = label;
-		if(value==null){ // just a label
-			this.fieldType = FIELD_TYPE.LABEL;
-		}else{
-			this.value = value;
-			this.description = description;
-			this.fieldType = FIELD_TYPE.STRING;
+        this.stringValue = stringValue;
+		this.fieldType = FIELD_TYPE.STRING;
 
-		}
 	}
 
+	public KVP(String label, String stringValue, String description) {
+		this(label,stringValue);
+		setDescription(description);
+ 
+	}
 	
-	public KVP(String label, int value, String description) {
+	public KVP(String label, int intValue) {
         this.label = label;
-		this.intValue = value;
-		this.description = description;
+		this.intValue = intValue;
 		this.fieldType = FIELD_TYPE.INT;
 	}
 
-	public KVP(String label, long value, String description) {
+	public KVP(String label, int intValue, String description) {
+        this(label,intValue);
+		setDescription(description);
+	}
+
+	public KVP(String label, long longValue) {
         this.label = label;
-		this.longValue = value;
-		this.description = description;
+		this.longValue = longValue;
 		this.fieldType = FIELD_TYPE.LONG;
+	}
+
+	public KVP(String label, long longValue, String description) {
+        this(label,longValue);
+		setDescription(description);
 	}
 
 	public KVP(String label, boolean value, String description) {
@@ -171,46 +179,58 @@ public class KVP extends DefaultMutableTreeNode{
 	}
 
 
-	/**
-	 * @param label
-	 * @param value
-	 * @param description
-	 */
-	public KVP(String label, byte[] value, String description) {
-        this.label = label;
-		this.byteValue = value;
+	public KVP(String label, byte[] byteArray) {
+		this.label = label;
+		this.byteValue = byteArray;
 		this.byteStart = 0;
-		this.byteLen = value.length;
-		this.description = description;
+		this.byteLen = byteArray.length;
 		this.fieldType = FIELD_TYPE.BYTES;
-		detailViews.add(new DetailView((HTMLSource)() -> getHTMLHexview(byteValue, byteStart, byteLen),"Hex View"));
+		detailViews.add(new DetailView((HTMLSource) () -> getHTMLHexview(byteValue, byteStart, byteLen), "Hex View"));
 	}
 
-	public KVP(String label, byte[] value, int offset, int len, String description) {
-        this.label = label;
-		this.byteValue = value;
+	public KVP(String label, byte[] byteArray, String description) {
+		this(label, byteArray);
+		setDescription(description);
+	}
+
+	public KVP(String label, byte[] byteArray, int offset, int len) {
+		this.label = label;
+		this.byteValue = byteArray;
 		this.byteStart = offset;
 		this.byteLen = len;
-		this.description = description;
 		this.fieldType = FIELD_TYPE.BYTES;
-		detailViews.add(new DetailView((HTMLSource)() -> getHTMLHexview(byteValue, byteStart, byteLen),"Hex View"));
+		detailViews.add(new DetailView((HTMLSource) () -> getHTMLHexview(byteValue, byteStart, byteLen), "Hex View"));
 	}
 
-	public KVP(String label, DVBString value, String description) {
+	public KVP(String label, byte[] byteArray, int offset, int len, String description) {
+		this(label, byteArray, offset, len);
+		setDescription(description);
+	}
+
+	public KVP(String label, DVBString dvbStringValue) {
         this.label = label;
-		this.dvbStringValue = value;
-		this.description = description;
+		this.dvbStringValue = dvbStringValue;
 		this.fieldType = FIELD_TYPE.DVBSTRING;
 	}
 
-	public KVP(String label, BigInteger value, String description) {
-
-        this.label = label;
-		this.bigIntegerValue = value;
-		this.fieldType = FIELD_TYPE.BIGINT;
-		this.description = description;
+	public KVP(String label, DVBString dvbStringValue, String description) {
+        this(label,dvbStringValue);
+		setDescription(description);
 	}
 
+	
+	public KVP(String label, BigInteger bigIntegerValue) {
+
+        this.label = label;
+		this.bigIntegerValue = bigIntegerValue;
+		this.fieldType = FIELD_TYPE.BIGINT;
+	}
+
+	public KVP(String label, BigInteger bigIntegerValue, String description) {
+        this(label, bigIntegerValue);
+		setDescription(description);
+	}
+	
 	public String getDescription() {
 		return description;
 	}
@@ -324,7 +344,7 @@ public class KVP extends DefaultMutableTreeNode{
 	 * @param b
 	 */
 	private void appendString(StringBuilder b) {
-		b.append(value);
+		b.append(stringValue);
 	}
 
 	/**

--- a/src/main/java/nl/digitalekabeltelevisie/controller/KVP.java
+++ b/src/main/java/nl/digitalekabeltelevisie/controller/KVP.java
@@ -139,11 +139,6 @@ public class KVP extends DefaultMutableTreeNode{
 		this.fieldType = FIELD_TYPE.LABEL;
 	}
 
-	public KVP(String label, ImageSource imageSource) {
-        this.label = label;
-		this.fieldType = FIELD_TYPE.LABEL;
-		detailViews.add(new DetailView(imageSource,""));
-	}
 	public KVP(String label, String value, String description) {
         this.label = label;
 		if(value==null){ // just a label
@@ -212,12 +207,6 @@ public class KVP extends DefaultMutableTreeNode{
 		this.dvbStringValue = value;
 		this.description = description;
 		this.fieldType = FIELD_TYPE.DVBSTRING;
-	}
-
-	public KVP(String label, HTMLSource htmlSource) {
-        this.label = label;
-		this.fieldType = FIELD_TYPE.LABEL;
-		detailViews.add(new DetailView(htmlSource,""));
 	}
 
 	public KVP(String label, BigInteger value, String description) {

--- a/src/main/java/nl/digitalekabeltelevisie/controller/KVP.java
+++ b/src/main/java/nl/digitalekabeltelevisie/controller/KVP.java
@@ -174,11 +174,6 @@ public class KVP extends DefaultMutableTreeNode{
 		setDescription(description);
 	}
 
-	public KVP(String label, boolean value, String description) {
-		this(label, value ? 1 : 0, description);
-	}
-
-
 	public KVP(String label, byte[] byteArray) {
 		this.label = label;
 		this.byteValue = byteArray;

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/AVCHDPacket.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/AVCHDPacket.java
@@ -74,7 +74,9 @@ public class AVCHDPacket extends TSPacket {
 	@Override
 	public DefaultMutableTreeNode getJTreeNode(final int modus) {
 
-		final DefaultMutableTreeNode t = new DefaultMutableTreeNode(new KVP(buildNodeLabel(),this));
+		final KVP kvp = new KVP(buildNodeLabel());
+		kvp.addHTMLSource(this, "AVCHD Packet");
+		final DefaultMutableTreeNode t = new DefaultMutableTreeNode(kvp);
 		final DefaultMutableTreeNode tpHeaderNode = new DefaultMutableTreeNode(new KVP("tp_extra_header",tp_extra_header,null));
 		tpHeaderNode.add(new DefaultMutableTreeNode(new KVP("Copy_permission_indicator",getCopyPermissionIndicator(),null)));
 		tpHeaderNode.add(new DefaultMutableTreeNode(new KVP("Arrival_time_stamp",arrivalTimestamp,printPCRTime(arrivalTimestamp))));

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/PSI.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/PSI.java
@@ -27,8 +27,6 @@
 
 package nl.digitalekabeltelevisie.data.mpeg;
 
-import javax.swing.tree.DefaultMutableTreeNode;
-
 import nl.digitalekabeltelevisie.controller.KVP;
 import nl.digitalekabeltelevisie.data.mpeg.dsmcc.DSMCCs;
 import nl.digitalekabeltelevisie.data.mpeg.psi.*;
@@ -67,9 +65,9 @@ public class PSI {
 	private final M7Fastscan m7fastscan = new M7Fastscan(this);
 	
 
-	public DefaultMutableTreeNode getJTreeNode(final int modus){
+	public KVP getJTreeNode(final int modus){
 
-		final DefaultMutableTreeNode t = new DefaultMutableTreeNode(new KVP("PSI"));
+		final KVP t = new  KVP("PSI");
 		t.add(pat.getJTreeNode(modus));
 		t.add(cat.getJTreeNode(modus));
 		t.add(bat.getJTreeNode(modus));

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/TSPacket.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/TSPacket.java
@@ -2,7 +2,7 @@
  *
  *  http://www.digitalekabeltelevisie.nl/dvb_inspector
  *
- *  This code is Copyright 2009-2021 by Eric Berendsen (e_berendsen@digitalekabeltelevisie.nl)
+ *  This code is Copyright 2009-2024 by Eric Berendsen (e_berendsen@digitalekabeltelevisie.nl)
  *
  *  This file is part of DVB Inspector.
  *
@@ -354,7 +354,9 @@ public class TSPacket implements HTMLSource, TreeNode{
 	@Override
 	public DefaultMutableTreeNode getJTreeNode(final int modus) {
 
-		final DefaultMutableTreeNode t = new DefaultMutableTreeNode(new KVP(buildNodeLabel(), this));
+		KVP kvp = new KVP(buildNodeLabel());
+		kvp.addHTMLSource(this, "TS Packet");
+		final DefaultMutableTreeNode t = new DefaultMutableTreeNode(kvp);
 		addMainPacketDetails(modus, t);
 		if(buffer.length>PAYLOAD_PACKET_LENGTH){
 			t.add(new DefaultMutableTreeNode(new KVP("FEC/timestamp",buffer,PAYLOAD_PACKET_LENGTH ,buffer.length - PAYLOAD_PACKET_LENGTH, null)));

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/TransportStream.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/TransportStream.java
@@ -479,20 +479,21 @@ public class TransportStream implements TreeNode{
 
 		KVP t = new KVP("Transport Stream "+psi.getPat().getTransportStreamId()).setCrumb("root");
 
-		t.add(new KVP("file",file.getPath(),null));
-		t.add(new KVP("size",file.length(),null));
-		t.add(new KVP("modified",new Date(file.lastModified()).toString(),null));
-		t.add(new KVP("TS packets",no_packets,null));
-		t.add(new KVP("packet size",packetLength,PreferencesManager.getPacketLengthModus()==0?"(detected)":"(forced)"));
-		t.add(new KVP("Error packets",error_packets,null));
-		t.add(new KVP("Sync Errors",sync_errors,null));
+		t.add(new KVP("file",file.getPath()));
+		t.add(new KVP("size",file.length()));
+
+		t.add(new KVP("modified",String.format("%1$tc", file.lastModified())));
+		t.add(new KVP("TS packets",no_packets));
+		t.add(new KVP("packet size",packetLength).setDescription(PreferencesManager.getPacketLengthModus()==0?"(detected)":"(forced)"));
+		t.add(new KVP("Error packets",error_packets));
+		t.add(new KVP("Sync Errors",sync_errors));
 		if(bitRate!= -1L){
-			t.add(new KVP("bitrate",bitRate,null));
-			t.add(new KVP("length (secs)",(file.length()* 8L)/bitRate,null));
+			t.add(new KVP("bitrate",bitRate));
+			t.add(new KVP("length (secs)",(file.length()* 8L)/bitRate));
 		}
 		if(bitRateTDT!= -1L){
-			t.add(new KVP("bitrate based on TDT",bitRateTDT,null));
-			t.add(new KVP("length (secs)",(file.length()* 8L)/bitRateTDT,null));
+			t.add(new KVP("bitrate based on TDT",bitRateTDT));
+			t.add(new KVP("length (secs)",(file.length()* 8L)/bitRateTDT));
 		}
 
 		t.add(psi.getJTreeNode(modus));

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/TransportStream.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/TransportStream.java
@@ -43,7 +43,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.swing.table.TableModel;
-import javax.swing.tree.DefaultMutableTreeNode;
 
 import nl.digitalekabeltelevisie.controller.KVP;
 import nl.digitalekabeltelevisie.controller.TreeNode;
@@ -475,33 +474,30 @@ public class TransportStream implements TreeNode{
 		return psi;
 	}
 
-	public DefaultMutableTreeNode getJTreeNode(int modus){
+	@Override
+	public KVP getJTreeNode(int modus){
 
-		KVP tsKvp = new KVP("Transport Stream "+psi.getPat().getTransportStreamId());
-		tsKvp.setCrumb("root");
-		DefaultMutableTreeNode t = new DefaultMutableTreeNode(tsKvp);
+		KVP t = new KVP("Transport Stream "+psi.getPat().getTransportStreamId()).setCrumb("root");
 
-		t.add(new DefaultMutableTreeNode(new KVP("file",file.getPath(),null)));
-		t.add(new DefaultMutableTreeNode(new KVP("size",file.length(),null)));
-		t.add(new DefaultMutableTreeNode(new KVP("modified",new Date(file.lastModified()).toString(),null)));
-		t.add(new DefaultMutableTreeNode(new KVP("TS packets",no_packets,null)));
-		t.add(new DefaultMutableTreeNode(new KVP("packet size",packetLength,PreferencesManager.getPacketLengthModus()==0?"(detected)":"(forced)")));
-		t.add(new DefaultMutableTreeNode(new KVP("Error packets",error_packets,null)));
-		t.add(new DefaultMutableTreeNode(new KVP("Sync Errors",sync_errors,null)));
+		t.add(new KVP("file",file.getPath(),null));
+		t.add(new KVP("size",file.length(),null));
+		t.add(new KVP("modified",new Date(file.lastModified()).toString(),null));
+		t.add(new KVP("TS packets",no_packets,null));
+		t.add(new KVP("packet size",packetLength,PreferencesManager.getPacketLengthModus()==0?"(detected)":"(forced)"));
+		t.add(new KVP("Error packets",error_packets,null));
+		t.add(new KVP("Sync Errors",sync_errors,null));
 		if(bitRate!= -1L){
-			t.add(new DefaultMutableTreeNode(new KVP("bitrate",bitRate,null)));
-			t.add(new DefaultMutableTreeNode(new KVP("length (secs)",(file.length()* 8L)/bitRate,null)));
+			t.add(new KVP("bitrate",bitRate,null));
+			t.add(new KVP("length (secs)",(file.length()* 8L)/bitRate,null));
 		}
 		if(bitRateTDT!= -1L){
-			t.add(new DefaultMutableTreeNode(new KVP("bitrate based on TDT",bitRateTDT,null)));
-			t.add(new DefaultMutableTreeNode(new KVP("length (secs)",(file.length()* 8L)/bitRateTDT,null)));
+			t.add(new KVP("bitrate based on TDT",bitRateTDT,null));
+			t.add(new KVP("length (secs)",(file.length()* 8L)/bitRateTDT,null));
 		}
 
 		t.add(psi.getJTreeNode(modus));
 		if(!psiOnlyModus(modus)){
-			KVP kvp = new KVP("PIDs");
-			kvp.addTableSource(this::getTableModel,"PIDs");
-			DefaultMutableTreeNode pidTreeNode = new DefaultMutableTreeNode(kvp);
+			KVP pidTreeNode = new KVP("PIDs").addTableSource(this::getTableModel,"PIDs");
 			t.add(pidTreeNode);
 			for (PID pid : pids) {
 				if((pid)!=null){
@@ -511,7 +507,7 @@ public class TransportStream implements TreeNode{
 			}
 			// TSPackets
             if (no_packets == 0) {
-                t.add(new DefaultMutableTreeNode(new KVP("Transport packets ")));
+                t.add(new KVP("Transport packets "));
             } else {
                 JTreeLazyList list = new JTreeLazyList(new TSPacketGetter(this, modus));
                 t.add(list.getJTreeNode(modus, "Transport packets "));

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/TransportStream.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/TransportStream.java
@@ -264,7 +264,13 @@ public class TransportStream implements TreeNode{
 	 * @throws IOException
 	 */
 	public void parseStream(java.awt.Component component) throws IOException {
-		try (PositionPushbackInputStream fileStream = getInputStream(component)) {
+		try (InputStream is = new FileInputStream(file);
+				PositionPushbackInputStream fileStream = (component==null) ? 
+						new PositionPushbackInputStream(new BufferedInputStream(is),300): 
+						new PositionPushbackInputStream(new BufferedInputStream(new ProgressMonitorLargeInputStream(component,
+						"Reading file \"" + file.getPath() +"\"",is, file.length())),300)
+	
+				) {
 			no_packets = 0;
 
 			pids = new PID[MAX_PIDS];
@@ -425,18 +431,6 @@ public class TransportStream implements TreeNode{
 			}
 		}
 	}
-
-
-	private PositionPushbackInputStream getInputStream(java.awt.Component component) throws IOException{
-		InputStream is = new FileInputStream(file);
-		long expectedSize=file.length();
-		if(component==null){
-			return new PositionPushbackInputStream(new BufferedInputStream(is),300);
-		}
-		return new PositionPushbackInputStream(new BufferedInputStream(new ProgressMonitorLargeInputStream(component,
-				"Reading file \"" + file.getPath() +"\"",is, expectedSize)),300);
-	}
-
 
 
 	@Override

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/BouquetNameDescriptor.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/BouquetNameDescriptor.java
@@ -37,9 +37,9 @@ public class BouquetNameDescriptor extends Descriptor{
 
 	private final DVBString  bouquetName;
 
-	public BouquetNameDescriptor(final byte[] b, final int offset, final TableSection parent) {
-		super(b, offset,parent);
-		bouquetName = new DVBString(b,offset+1);
+	public BouquetNameDescriptor(final byte[] b, final TableSection parent) {
+		super(b, parent);
+		bouquetName = new DVBString(b,1);
 	}
 
 	public DVBString getBouquetName() {
@@ -56,7 +56,7 @@ public class BouquetNameDescriptor extends Descriptor{
 	@Override
 	public DefaultMutableTreeNode getJTreeNode(final int modus){
 		final DefaultMutableTreeNode t = super.getJTreeNode(modus);
-		t.add(new DefaultMutableTreeNode(new KVP("bouquet_name",bouquetName ,null)));
+		t.add(new KVP("bouquet_name",bouquetName));
 		return t;
 	}
 

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/ComponentDescriptor.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/ComponentDescriptor.java
@@ -2,7 +2,7 @@
  * 
  *  http://www.digitalekabeltelevisie.nl/dvb_inspector
  * 
- *  This code is Copyright 2009-2020 by Eric Berendsen (e_berendsen@digitalekabeltelevisie.nl)
+ *  This code is Copyright 2009-2024 by Eric Berendsen (e_berendsen@digitalekabeltelevisie.nl)
  * 
  *  This file is part of DVB Inspector.
  * 
@@ -27,9 +27,10 @@
 
 package nl.digitalekabeltelevisie.data.mpeg.descriptors;
 
-import static nl.digitalekabeltelevisie.util.Utils.*;
-
-import javax.swing.tree.DefaultMutableTreeNode;
+import static nl.digitalekabeltelevisie.util.Utils.MASK_4BITS;
+import static nl.digitalekabeltelevisie.util.Utils.MASK_8BITS;
+import static nl.digitalekabeltelevisie.util.Utils.getISO8859_1String;
+import static nl.digitalekabeltelevisie.util.Utils.getInt;
 
 import nl.digitalekabeltelevisie.controller.DVBString;
 import nl.digitalekabeltelevisie.controller.KVP;
@@ -53,14 +54,14 @@ public class ComponentDescriptor extends LanguageDependentEitDescriptor{
 
 	private final DVBString text;
 
-	public ComponentDescriptor(final byte[] b, final int offset, final TableSection parent) {
-		super(b, offset, parent);
-		streamContentExt = getInt(b, offset + 2, 1, 0xF0) >> 4;
-		streamContent = getInt(b, offset + 2, 1, MASK_4BITS);
-		componentType = getInt(b, offset + 3, 1, MASK_8BITS);
-		componentTag = getInt(b, offset + 4, 1, MASK_8BITS);
-		iso639LanguageCode = getISO8859_1String(b, offset + 5, 3);
-		text =  new DVBString(b, offset + 8, descriptorLength - 6);
+	public ComponentDescriptor(final byte[] b, final TableSection parent) {
+		super(b, parent);
+		streamContentExt = getInt(b, 2, 1, 0xF0) >> 4;
+		streamContent = getInt(b, 2, 1, MASK_4BITS);
+		componentType = getInt(b, 3, 1, MASK_8BITS);
+		componentTag = getInt(b, 4, 1, MASK_8BITS);
+		iso639LanguageCode = getISO8859_1String(b, 5, 3);
+		text =  new DVBString(b, 8, descriptorLength - 6);
 	}
 
 	@Override
@@ -69,14 +70,14 @@ public class ComponentDescriptor extends LanguageDependentEitDescriptor{
 	}
 
 	@Override
-	public DefaultMutableTreeNode getJTreeNode(final int modus) {
-		final DefaultMutableTreeNode t = super.getJTreeNode(modus);
-		t.add(new DefaultMutableTreeNode(new KVP("stream_content_ext", streamContentExt, null)));
-		t.add(new DefaultMutableTreeNode(new KVP("stream_content", streamContent, null)));
-		t.add(new DefaultMutableTreeNode(new KVP("component_type", componentType, getStreamTypeString())));
-		t.add(new DefaultMutableTreeNode(new KVP("component_tag", componentTag,	null)));
-		t.add(new DefaultMutableTreeNode(new KVP("ISO_639_language_code", iso639LanguageCode, null)));
-		t.add(new DefaultMutableTreeNode(new KVP("text", text, null)));
+	public KVP getJTreeNode(final int modus) {
+		final KVP t = super.getJTreeNode(modus);
+		t.add(new KVP("stream_content_ext", streamContentExt));
+		t.add(new KVP("stream_content", streamContent));
+		t.add(new KVP("component_type", componentType).setDescription(getStreamTypeString()));
+		t.add(new KVP("component_tag", componentTag));
+		t.add(new KVP("ISO_639_language_code", iso639LanguageCode));
+		t.add(new KVP("text", text));
 		return t;
 	}
 
@@ -88,16 +89,8 @@ public class ComponentDescriptor extends LanguageDependentEitDescriptor{
 		return streamContent;
 	}
 
-	public void setStreamContent(final int maximumBitrate) {
-		this.streamContent = maximumBitrate;
-	}
-
 	public int getReserved() {
 		return streamContentExt;
-	}
-
-	public void setReserved(final int reserverd) {
-		this.streamContentExt = reserverd;
 	}
 
 	public int getStreamContentExt() {

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/ContentDescriptor.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/ContentDescriptor.java
@@ -41,73 +41,29 @@ public class ContentDescriptor extends Descriptor {
 
 	private List<ContentItem> contentList = new ArrayList<>();
 
+	public static record ContentItem(int contentNibbleLevel1, int contentNibbleLevel2, int user_byte) implements TreeNode{
 
-	public static class ContentItem implements TreeNode{
-		/**
-		 *
-		 */
-		private final int contentNibbleLevel1 ;
-		private final int contentNibbleLevel2 ;
-		private final int user_byte ;
-
-
-
-		public ContentItem(final int contentNibbleLevel1, final int contentNibbleLevel2, final int user_byte) {
-			super();
-			this.contentNibbleLevel1 = contentNibbleLevel1;
-			this.contentNibbleLevel2 = contentNibbleLevel2;
-			this.user_byte = user_byte;
-		}
-
-
-
-		public DefaultMutableTreeNode getJTreeNode(final int modus){
-			final DefaultMutableTreeNode s=new DefaultMutableTreeNode(new KVP("content type"));
-			s.add(new DefaultMutableTreeNode(new KVP("content_nibble_level_1",contentNibbleLevel1,getContentNibbleLevel1String(contentNibbleLevel1))));
-			s.add(new DefaultMutableTreeNode(new KVP("content_nibble_level_2",contentNibbleLevel2,getContentNibbleLevel2String(contentNibbleLevel1, contentNibbleLevel2))));
-			s.add(new DefaultMutableTreeNode(new KVP("user_byte",user_byte,null)));
+		@Override
+		public KVP getJTreeNode(final int modus) {
+			final KVP s = new KVP("content type");
+			s.add(new KVP("content_nibble_level_1", contentNibbleLevel1).setDescription(getContentNibbleLevel1String(contentNibbleLevel1)));
+			s.add(new KVP("content_nibble_level_2", contentNibbleLevel2).setDescription(getContentNibbleLevel2String(contentNibbleLevel1, contentNibbleLevel2)));
+			s.add(new KVP("user_byte", user_byte));
 			return s;
 		}
 
-
-
-		@Override
-		public String toString(){
-			return "content_nibble_level_1:"+contentNibbleLevel1 + ", content_nibble_level_2:"+contentNibbleLevel2;
-		}
-
-
-
-		public int getContentNibbleLevel1() {
-			return contentNibbleLevel1;
-		}
-
-
-
-		public int getContentNibbleLevel2() {
-			return contentNibbleLevel2;
-		}
-
-
-
-		public int getUserByte() {
-			return user_byte;
-		}
-
-
-
 	}
 
-	public ContentDescriptor(final byte[] b, final int offset, final TableSection parent) {
-		super(b, offset, parent);
+	public ContentDescriptor(byte[] b, TableSection parent) {
+		super(b, parent);
 		int t = 0;
 		while (t < descriptorLength) {
-			final int cNibble1 = Utils.getInt(b, offset + t + 2, 1, 0xF0) >> 4;
-			final int cNnibble2 = Utils.getInt(b, offset + t + 2, 1, Utils.MASK_4BITS);
-			final int user_byte = Utils.getInt(b, offset + t + 3, 1, Utils.MASK_8BITS);
-			final ContentItem s = new ContentItem(cNibble1, cNnibble2, user_byte);
-			contentList.add(s);
-			t += 2;
+			final int cNibble1 = Utils.getInt(b, t + 2, 1, 0xF0) >> 4;
+		final int cNnibble2 = Utils.getInt(b, t + 2, 1, Utils.MASK_4BITS);
+		final int user_byte = Utils.getInt(b, t + 3, 1, Utils.MASK_8BITS);
+		final ContentItem s = new ContentItem(cNibble1, cNnibble2, user_byte);
+		contentList.add(s);
+		t += 2;
 		}
 	}
 
@@ -123,173 +79,176 @@ public class ContentDescriptor extends Descriptor {
 	}
 
 	public static String getContentNibbleLevel1String(final int nibble1) {
-		switch (nibble1) {
-		case 0x0: return "undefined content";
-		case 0x1: return "Movie/Drama:";
-		case 0x2: return "News/Current affairs:";
-		case 0x3: return "Show/Game show:";
-		case 0x4: return "Sports:";
-		case 0x5: return "Children's/Youth programmes:";
-		case 0x6: return "Music/Ballet/Dance:";
-		case 0x7: return "Arts/Culture (without music):";
-		case 0x8: return "Social/Political issues/Economics:";
-		case 0x9: return "Education/Science/Factual topics:";
-		case 0xA: return "Leisure hobbies:";
-		case 0xB: return "Special characteristics:";
-		case 0xC: return "Adult:";
-		case 0xF: return "user defined";
-		default: return "reserved for future use:";
-		}
+		return switch (nibble1) {
+		case 0x0 -> "undefined content";
+		case 0x1 -> "Movie/Drama:";
+		case 0x2 -> "News/Current affairs:";
+		case 0x3 -> "Show/Game show:";
+		case 0x4 -> "Sports:";
+		case 0x5 -> "Children's/Youth programmes:";
+		case 0x6 -> "Music/Ballet/Dance:";
+		case 0x7 -> "Arts/Culture (without music):";
+		case 0x8 -> "Social/Political issues/Economics:";
+		case 0x9 -> "Education/Science/Factual topics:";
+		case 0xA -> "Leisure hobbies:";
+		case 0xB -> "Special characteristics:";
+		case 0xC -> "Adult:";
+		case 0xF -> "user defined";
+		default -> "reserved for future use:";
+		};
 	}
 
 	public static String getContentNibbleLevel2String(final int nibble1,final int nibble2) {
-		switch (nibble1) {
-		case 0x0: return "";
+		return switch (nibble1) {
+		case 0x0:
+			yield "";
 		case 0x1: // Movie/Drama:
-			switch (nibble2) {
-			case 0x0: return "movie/drama (general)";
-			case 0x1: return "detective/thriller";
-			case 0x2: return "adventure/western/war";
-			case 0x3: return "science fiction/fantasy/horror";
-			case 0x4: return "comedy";
-			case 0x5: return "soap/melodrama/folkloric";
-			case 0x6: return "romance";
-			case 0x7: return "serious/classical/religious/historical movie/drama";
-			case 0x8: return "adult movie/drama";
-			case 0xF: return "user defined";
-			default: return "reserved for future use";
-			}
+			yield switch (nibble2) {
+						case 0x0 -> "movie/drama (general)";
+						case 0x1 -> "detective/thriller";
+						case 0x2 -> "adventure/western/war";
+						case 0x3 -> "science fiction/fantasy/horror";
+						case 0x4 -> "comedy";
+						case 0x5 -> "soap/melodrama/folkloric";
+						case 0x6 -> "romance";
+						case 0x7 -> "serious/classical/religious/historical movie/drama";
+						case 0x8 -> "adult movie/drama";
+						case 0xF -> "user defined";
+						default -> "reserved for future use";
+						};
 		case 0x2: // News/Current affairs:
-			switch (nibble2) {
-			case 0x0: return "news/current affairs (general)";
-			case 0x1: return "news/weather report";
-			case 0x2: return "news magazine";
-			case 0x3: return "documentary";
-			case 0x4: return "discussion/interview/debate";
-			case 0xF: return "user defined";
-			default: return "reserved for future use";
-			}
+			yield switch (nibble2) {
+						case 0x0 -> "news/current affairs (general)";
+						case 0x1 -> "news/weather report";
+						case 0x2 -> "news magazine";
+						case 0x3 -> "documentary";
+						case 0x4 -> "discussion/interview/debate";
+						case 0xF -> "user defined";
+						default -> "reserved for future use";
+						};
 		case 0x3: // Show/Game show:
-			switch (nibble2) {
-			case 0x0 : return "show/game show (general)";
-			case 0x1 : return "game show/quiz/contest";
-			case 0x2 : return "variety show";
-			case 0x3 : return "talk show";
-			case 0xF: return "user defined";
-			default: return "reserved for future use";
-			}
+			yield switch (nibble2) {
+						case 0x0 -> "show/game show (general)";
+						case 0x1 -> "game show/quiz/contest";
+						case 0x2 -> "variety show";
+						case 0x3 -> "talk show";
+						case 0xF -> "user defined";
+						default -> "reserved for future use";
+						};
 		case 0x4: // Sports:
-			switch (nibble2) {
-			case 0x0 : return "sports (general)";
-			case 0x1 : return "special events (Olympic Games, World Cup, etc.)";
-			case 0x2 : return "sports magazines";
-			case 0x3 : return "football/soccer";
-			case 0x4 : return "tennis/squash";
-			case 0x5 : return "team sports (excluding football)";
-			case 0x6 : return "athletics";
-			case 0x7 : return "motor sport";
-			case 0x8 : return "water sport";
-			case 0x9 : return "winter sports";
-			case 0xA : return "equestrian";
-			case 0xB : return "martial sports";
-			case 0xF: return "user defined";
-			default: return "reserved for future use";
-			}
+			yield switch (nibble2) {
+						case 0x0 -> "sports (general)";
+						case 0x1 -> "special events (Olympic Games, World Cup, etc.)";
+						case 0x2 -> "sports magazines";
+						case 0x3 -> "football/soccer";
+						case 0x4 -> "tennis/squash";
+						case 0x5 -> "team sports (excluding football)";
+						case 0x6 -> "athletics";
+						case 0x7 -> "motor sport";
+						case 0x8 -> "water sport";
+						case 0x9 -> "winter sports";
+						case 0xA -> "equestrian";
+						case 0xB -> "martial sports";
+						case 0xF -> "user defined";
+						default -> "reserved for future use";
+						};
 		case 0x5: // Children's/Youth programmes:
-			switch (nibble2) {
-			case 0x0 : return "children's/youth programmes (general)";
-			case 0x1 : return "pre-school children's programmes";
-			case 0x2 : return "entertainment programmes for 6 to14";
-			case 0x3 : return "entertainment programmes for 10 to 16";
-			case 0x4 : return "informational/educational/school programmes";
-			case 0x5 : return "cartoons/puppets";
-			case 0xF: return "user defined";
-			default: return "reserved for future use";
-			}
+			yield switch (nibble2) {
+						case 0x0 -> "children's/youth programmes (general)";
+						case 0x1 -> "pre-school children's programmes";
+						case 0x2 -> "entertainment programmes for 6 to14";
+						case 0x3 -> "entertainment programmes for 10 to 16";
+						case 0x4 -> "informational/educational/school programmes";
+						case 0x5 -> "cartoons/puppets";
+						case 0xF -> "user defined";
+						default -> "reserved for future use";
+						};
 		case 0x6: // Music/Ballet/Dance:
-			switch (nibble2) {
-			case 0x0 : return "music/ballet/dance (general)";
-			case 0x1 : return "rock/pop";
-			case 0x2 : return "serious music/classical music";
-			case 0x3 : return "folk/traditional music";
-			case 0x4 : return "jazz";
-			case 0x5 : return "musical/opera";
-			case 0x6 : return "ballet";
-			case 0xF: return "user defined";
-			default: return "reserved for future use";
-			}
+			yield switch (nibble2) {
+						case 0x0 -> "music/ballet/dance (general)";
+						case 0x1 -> "rock/pop";
+						case 0x2 -> "serious music/classical music";
+						case 0x3 -> "folk/traditional music";
+						case 0x4 -> "jazz";
+						case 0x5 -> "musical/opera";
+						case 0x6 -> "ballet";
+						case 0xF -> "user defined";
+						default -> "reserved for future use";
+						};
 		case 0x7: // Arts/Culture (without music):
-			switch (nibble2) {
-			case 0x0 : return "arts/culture (without music, general)";
-			case 0x1 : return "performing arts";
-			case 0x2 : return "fine arts";
-			case 0x3 : return "religion";
-			case 0x4 : return "popular culture/traditional arts";
-			case 0x5 : return "literature";
-			case 0x6 : return "film/cinema";
-			case 0x7 : return "experimental film/video";
-			case 0x8 : return "broadcasting/press";
-			case 0x9 : return "new media";
-			case 0xA : return "arts/culture magazines";
-			case 0xB : return "fashion";
-			case 0xF: return "user defined";
-			default: return "reserved for future use";
-			}
+			yield switch (nibble2) {
+						case 0x0 -> "arts/culture (without music, general)";
+						case 0x1 -> "performing arts";
+						case 0x2 -> "fine arts";
+						case 0x3 -> "religion";
+						case 0x4 -> "popular culture/traditional arts";
+						case 0x5 -> "literature";
+						case 0x6 -> "film/cinema";
+						case 0x7 -> "experimental film/video";
+						case 0x8 -> "broadcasting/press";
+						case 0x9 -> "new media";
+						case 0xA -> "arts/culture magazines";
+						case 0xB -> "fashion";
+						case 0xF -> "user defined";
+						default -> "reserved for future use";
+						};
 		case 0x8: // Social/Political issues/Economics:
-			switch (nibble2) {
-			case 0x0 : return "social/political issues/economics (general)";
-			case 0x1 : return "magazines/reports/documentary";
-			case 0x2 : return "economics/social advisory";
-			case 0x3 : return "remarkable people";
-			case 0xF: return "user defined";
-			default: return "reserved for future use";
-			}
+			yield switch (nibble2) {
+						case 0x0 -> "social/political issues/economics (general)";
+						case 0x1 -> "magazines/reports/documentary";
+						case 0x2 -> "economics/social advisory";
+						case 0x3 -> "remarkable people";
+						case 0xF -> "user defined";
+						default -> "reserved for future use";
+						};
 		case 0x9: // Education/Science/Factual topics:
-			switch (nibble2) {
-			case 0x0 : return "education/science/factual topics (general)";
-			case 0x1 : return "nature/animals/environment";
-			case 0x2 : return "technology/natural sciences";
-			case 0x3 : return "medicine/physiology/psychology";
-			case 0x4 : return "foreign countries/expeditions";
-			case 0x5 : return "social/spiritual sciences";
-			case 0x6 : return "further education";
-			case 0x7 : return "languages";
-			case 0xF: return "user defined";
-			default: return "reserved for future use";
-			}
+			yield switch (nibble2) {
+						case 0x0 -> "education/science/factual topics (general)";
+						case 0x1 -> "nature/animals/environment";
+						case 0x2 -> "technology/natural sciences";
+						case 0x3 -> "medicine/physiology/psychology";
+						case 0x4 -> "foreign countries/expeditions";
+						case 0x5 -> "social/spiritual sciences";
+						case 0x6 -> "further education";
+						case 0x7 -> "languages";
+						case 0xF -> "user defined";
+						default -> "reserved for future use";
+						};
 		case 0xA: // Leisure hobbies:
-			switch (nibble2) {
-			case 0x0 : return "leisure hobbies (general)";
-			case 0x1 : return "tourism/travel";
-			case 0x2 : return "handicraft";
-			case 0x3 : return "motoring";
-			case 0x4 : return "fitness and health";
-			case 0x5 : return "cooking";
-			case 0x6 : return "advertisement/shopping";
-			case 0x7 : return "gardening";
-			case 0xF: return "user defined";
-			default: return "reserved for future use";
-			}
+			yield switch (nibble2) {
+						case 0x0 -> "leisure hobbies (general)";
+						case 0x1 -> "tourism/travel";
+						case 0x2 -> "handicraft";
+						case 0x3 -> "motoring";
+						case 0x4 -> "fitness and health";
+						case 0x5 -> "cooking";
+						case 0x6 -> "advertisement/shopping";
+						case 0x7 -> "gardening";
+						case 0xF -> "user defined";
+						default -> "reserved for future use";
+						};
 		case 0xB: // Special characteristics:
-			switch (nibble2) {
-			case 0x0 : return "original language";
-			case 0x1 : return "black and white";
-			case 0x2 : return "unpublished";
-			case 0x3 : return "live broadcast";
-			case 0x4 : return "plano-stereoscopic";
-			case 0x5 : return "local or regional";
-			case 0xF: return "user defined";
-			default: return "reserved for future use";
-			}
+			yield switch (nibble2) {
+						case 0x0 -> "original language";
+						case 0x1 -> "black and white";
+						case 0x2 -> "unpublished";
+						case 0x3 -> "live broadcast";
+						case 0x4 -> "plano-stereoscopic";
+						case 0x5 -> "local or regional";
+						case 0xF -> "user defined";
+						default -> "reserved for future use";
+						};
 		case 0xC: // Adult:
-			switch (nibble2) {
-			case 0x0 : return "adult (general)";
-			case 0xF: return "user defined";
-			default: return "reserved for future use";
-			}
-		case 0xF: return "";
-		default: return "reserved for future use";
-		}
+			yield switch (nibble2) {
+						case 0x0 -> "adult (general)";
+						case 0xF -> "user defined";
+						default -> "reserved for future use";
+						};
+		case 0xF:
+			yield "";
+		default:
+			yield "reserved for future use";
+		};
 	}
 
 	@Override

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/DescriptorFactory.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/DescriptorFactory.java
@@ -429,13 +429,13 @@ public final class DescriptorFactory {
 		case 0x4C:
 			return new TimeShiftedServiceDescriptor(data, 0, tableSection);
 		case 0x4D:
-			return new ShortEventDescriptor(data, 0, tableSection);
+			return new ShortEventDescriptor(data, tableSection);
 		case 0x4E:
-			return new ExtendedEventDescriptor(data, 0, tableSection);
+			return new ExtendedEventDescriptor(data, tableSection);
 		case 0x4F:
 			return new TimeShiftedEventDescriptor(data, 0, tableSection);
 		case 0x50:
-			return new ComponentDescriptor(data, 0, tableSection);
+			return new ComponentDescriptor(data, tableSection);
 		case 0x51:
 			return new MosaicDescriptor(data, 0, tableSection);
 		case 0x52:

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/DescriptorFactory.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/DescriptorFactory.java
@@ -584,22 +584,21 @@ public final class DescriptorFactory {
 
 		switch (toUnsignedInt(data[0])) {
 		case 0x0C:
-			return new IPMACPlatformNameDescriptor(data, 0, tableSection);
+			return new IPMACPlatformNameDescriptor(data, tableSection);
 		case 0x0D:
-			return new IPMACPlatformProviderNameDescriptor(data, 0, tableSection);
+			return new IPMACPlatformProviderNameDescriptor(data, tableSection);
 		case 0x0F:
-			return new TargetIPSlashDescriptor(data, 0, tableSection);
+			return new TargetIPSlashDescriptor(data, tableSection);
 		case 0x13:
-			return new IPMACStreamLocationDescriptor(data, 0, tableSection);
+			return new IPMACStreamLocationDescriptor(data, tableSection);
 		default:
-			Descriptor d = new INTDescriptor(data, 0, tableSection);
+			Descriptor d = new INTDescriptor(data, tableSection);
 			logger.info("Not implemented IntDescriptor:" + toUnsignedInt(data[0]) + " ("
-					+ INTDescriptor.getDescriptorname(toUnsignedInt(data[0]), tableSection)
-					+ ")in section " + TableSection.getTableType(tableSection.getTableId()) + " (" + tableSection
-					+ ",) data=" + d.getRawDataString());
+					+ INTDescriptor.getDescriptorname(toUnsignedInt(data[0]), tableSection) + ")in section "
+					+ TableSection.getTableType(tableSection.getTableId()) + " (" + tableSection + ",) data=" + d.getRawDataString());
 			return d;
 		}
-		
+
 	}
 
 	private static Descriptor getUNTDescriptor(final byte[] data, final TableSection tableSection) {

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/DescriptorFactory.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/DescriptorFactory.java
@@ -388,11 +388,11 @@ public final class DescriptorFactory {
 		switch(descriptor_tag_extension){
 		
 		case 0x03:
-			return new HEVCTimingAndHRDDescriptor(data, 0, tableSection);
+			return new HEVCTimingAndHRDDescriptor(data, tableSection);
 		case 0x14:
-			return new JpegXsVideoDescriptor(data, 0, tableSection);
+			return new JpegXsVideoDescriptor(data, tableSection);
 		default:
-			MPEGExtensionDescriptor d = new MPEGExtensionDescriptor(data, 0, tableSection);
+			MPEGExtensionDescriptor d = new MPEGExtensionDescriptor(data, tableSection);
 			logger.warning("unimplemented MPEGExtensionDescriptor:" +
 					d.getDescriptorTagString() +
 					", TableSection:" + tableSection);

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/DescriptorFactory.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/DescriptorFactory.java
@@ -419,11 +419,11 @@ public final class DescriptorFactory {
 		case 0x47:
 			return new BouquetNameDescriptor(data, 0, tableSection);
 		case 0x48:
-			return new ServiceDescriptor(data, 0, tableSection);
+			return new ServiceDescriptor(data, tableSection);
 		case 0x49:
 			return new CountryAvailabilityDescriptor(data, 0, tableSection);
 		case 0x4A:
-			return new LinkageDescriptor(data, 0, tableSection);
+			return new LinkageDescriptor(data, tableSection);
 		case 0x4B:
 			return new NVODReferenceDescriptor(data, 0, tableSection);
 		case 0x4C:
@@ -455,11 +455,11 @@ public final class DescriptorFactory {
 		case 0x5A:
 			return new TerrestrialDeliverySystemDescriptor(data, 0, tableSection);
 		case 0x5B:
-			return new MultilingualNetworkNameDescriptor(data, 0, tableSection);
+			return new MultilingualNetworkNameDescriptor(data, tableSection);
 		case 0x5C:
-			return new MultilingualBouquetNameDescriptor(data, 0, tableSection);
+			return new MultilingualBouquetNameDescriptor(data, tableSection);
 		case 0x5D:
-			return new MultilingualServiceNameDescriptor(data, 0, tableSection);
+			return new MultilingualServiceNameDescriptor(data, tableSection);
 		case 0x5F:
 			return new PrivateDataSpecifierDescriptor(data, 0, tableSection);
 		case 0x62:
@@ -487,7 +487,7 @@ public final class DescriptorFactory {
 		case 0x70:
 			return new AdaptationFieldDataDescriptor(data, 0, tableSection);
 		case 0x71:
-			return new ServiceIdentifierDescriptor(data, 0, tableSection);
+			return new ServiceIdentifierDescriptor(data, tableSection);
 		case 0x72:
 			return new ServiceAvailabilityDescriptor(data, 0, tableSection);
 		case 0x73:

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/DescriptorFactory.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/DescriptorFactory.java
@@ -443,7 +443,7 @@ public final class DescriptorFactory {
 		case 0x53:
 			return new CAIdentifierDescriptor(data, 0, tableSection);
 		case 0x54:
-			return new ContentDescriptor(data, 0, tableSection);
+			return new ContentDescriptor(data, tableSection);
 		case 0x55:
 			return new ParentalRatingDescriptor(data, 0, tableSection);
 		case 0x56:

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/DescriptorFactory.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/DescriptorFactory.java
@@ -260,7 +260,7 @@ public final class DescriptorFactory {
 			case 0x83:
 				return new NordigLogicalChannelDescriptorV1(data, 0, tableSection, descriptorContext);
 			case 0x87:
-				return new NordigLogicalChannelDescriptorV2(data, 0, tableSection, descriptorContext);
+				return new NordigLogicalChannelDescriptorV2(data, tableSection, descriptorContext);
 			}
 
 
@@ -272,7 +272,7 @@ public final class DescriptorFactory {
 		} else if (private_data_specifier == 0xa4) { // Canal + International
 			switch (descriptor_tag) {
 			case 0x80:
-				return new CosBatSelectionDescriptor (data, 0, tableSection);
+				return new CosBatSelectionDescriptor (data, tableSection);
 			case 0x81:
 				return new CosInformationParametersDescriptor(data, 0, tableSection);
 			case 0x83:
@@ -287,7 +287,7 @@ public final class DescriptorFactory {
 			case 0x86:
 				return new ServiceAttributeDescriptor(data, 0, tableSection);
 			case 0x89:
-				return new GuidanceDescriptor(data, 0, tableSection);
+				return new GuidanceDescriptor(data, tableSection);
 			}
 		} else if (private_data_specifier >= 0x00003200 && private_data_specifier <= 0x0000320F ) { // FREE TV AUSTRALIA OPERATIONAL PRACTICE OP-40
 			switch (descriptor_tag) {
@@ -610,7 +610,7 @@ public final class DescriptorFactory {
 		case 0x03:
 			return new SSULocationDescriptor(data, 0, tableSection);
 		case 0x04:
-			return new MessageDescriptor(data, 0, tableSection);
+			return new MessageDescriptor(data, tableSection);
 		case 0x05:
 			return new SSUEventNameDescriptor(data, 0, tableSection);
 		case 0x06:

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/DescriptorFactory.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/DescriptorFactory.java
@@ -417,7 +417,7 @@ public final class DescriptorFactory {
 		case 0x46: // semantics for the VBI teletext descriptor is the same as defined for the teletext descriptor
 			return new TeletextDescriptor(data, 0, tableSection);
 		case 0x47:
-			return new BouquetNameDescriptor(data, 0, tableSection);
+			return new BouquetNameDescriptor(data, tableSection);
 		case 0x48:
 			return new ServiceDescriptor(data, tableSection);
 		case 0x49:
@@ -564,7 +564,7 @@ public final class DescriptorFactory {
 		case 0x22:
 			return new ServiceProminenceDescriptor(data, 0, tableSection);
 		case 0x23:
-			return new VvcSubpicturesDescriptor(data, 0, tableSection);
+			return new VvcSubpicturesDescriptor(data, tableSection);
 
 		default:
 			DVBExtensionDescriptor d = new DVBExtensionDescriptor(data, 0, tableSection);
@@ -633,7 +633,7 @@ public final class DescriptorFactory {
 		case 0x00:
 			return new ApplicationDescriptor(data, 0, tableSection);
 		case 0x01:
-			return new ApplicationNameDescriptor(data, 0, tableSection);
+			return new ApplicationNameDescriptor(data, tableSection);
 		case 0x02:
 			return new TransportProtocolDescriptor(data, 0, tableSection);
 		case 0x03:

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/DescriptorFactory.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/DescriptorFactory.java
@@ -552,7 +552,7 @@ public final class DescriptorFactory {
 		case 0x13:
 			return new URILinkageDescriptor(data, 0, tableSection);
 		case 0x14:
-			return new CIAncillaryDataDescriptor(data, 0, tableSection);
+			return new CIAncillaryDataDescriptor(data, tableSection);
 		case 0x15:
 			return new AC4Descriptor(data, 0, tableSection);
 		case 0x17:
@@ -560,7 +560,7 @@ public final class DescriptorFactory {
 		case 0x19:
 			return new AudioPreselectionDescriptor(data, 0, tableSection);
 		case 0x20:
-			return new TtmlSubtitlingDescriptor(data, 0, tableSection);
+			return new TtmlSubtitlingDescriptor(data, tableSection);
 		case 0x22:
 			return new ServiceProminenceDescriptor(data, 0, tableSection);
 		case 0x23:

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/ExtendedEventDescriptor.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/ExtendedEventDescriptor.java
@@ -2,7 +2,7 @@
  *
  *  http://www.digitalekabeltelevisie.nl/dvb_inspector
  *
- *  This code is Copyright 2009-2020 by Eric Berendsen (e_berendsen@digitalekabeltelevisie.nl)
+ *  This code is Copyright 2009-2024 by Eric Berendsen (e_berendsen@digitalekabeltelevisie.nl)
  *
  *  This file is part of DVB Inspector.
  *
@@ -32,8 +32,6 @@ import static nl.digitalekabeltelevisie.util.Utils.*;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.swing.tree.DefaultMutableTreeNode;
-
 import nl.digitalekabeltelevisie.controller.DVBString;
 import nl.digitalekabeltelevisie.controller.KVP;
 import nl.digitalekabeltelevisie.controller.TreeNode;
@@ -54,33 +52,27 @@ public class ExtendedEventDescriptor extends LanguageDependentEitDescriptor{
 		public DVBString getItem() {
 			return item;
 		}
-		public void setItem(final DVBString item) {
-			this.item = item;
-		}
 		public DVBString getItemDescription() {
 			return itemDescription;
 		}
-		public void setItemDescription(final DVBString itemDescription) {
-			this.itemDescription = itemDescription;
-		}
 
-		public DefaultMutableTreeNode getJTreeNode(final int modus){
-			DefaultMutableTreeNode s;
-			if(simpleModus(modus)){
-				s=new DefaultMutableTreeNode(new KVP("item",itemDescription+": "+item,null));
-			}else{
-				s=new DefaultMutableTreeNode(new KVP("item"));
-				s.add(new DefaultMutableTreeNode(new KVP("item_description_encoding",itemDescription.getEncodingString(),null)));
-				s.add(new DefaultMutableTreeNode(new KVP("item_description_length",itemDescription.getLength(),null)));
-				s.add(new DefaultMutableTreeNode(new KVP("item_description",itemDescription,null)));
-				s.add(new DefaultMutableTreeNode(new KVP("item_encoding",item.getEncodingString(),null)));
-				s.add(new DefaultMutableTreeNode(new KVP("item_length",item.getLength(),null)));
-				s.add(new DefaultMutableTreeNode(new KVP("item",item,null)));
+		@Override
+		public KVP getJTreeNode(final int modus) {
+			KVP s;
+			if (simpleModus(modus)) {
+				s = new KVP("item", itemDescription + ": " + item, null);
+			} else {
+				s = new KVP("item");
+				s.add(new KVP("item_description_encoding", itemDescription.getEncodingString()));
+				s.add(new KVP("item_description_length", itemDescription.getLength()));
+				s.add(new KVP("item_description", itemDescription));
+				s.add(new KVP("item_encoding", item.getEncodingString()));
+				s.add(new KVP("item_length", item.getLength()));
+				s.add(new KVP("item", item));
 			}
 
 			return s;
 		}
-
 
 	}
 
@@ -88,19 +80,19 @@ public class ExtendedEventDescriptor extends LanguageDependentEitDescriptor{
 	private final int lastDescriptorNumber;
 	private String  iso639LanguageCode;
 	private final int lengthOfItems;
-	private final List<Item> itemList = new ArrayList<Item>();
+	private final List<Item> itemList = new ArrayList<>();
 
 	private final DVBString text;
 
-	public ExtendedEventDescriptor(final byte[] b, final int offset, final TableSection parent) {
-		super(b, offset,parent);
-		descriptorNumber = getInt(b, offset+2, 1, 0xF0)>>4;
-		lastDescriptorNumber = getInt(b, offset+2, 1, MASK_4BITS);
-		iso639LanguageCode = getISO8859_1String(b,offset+3,3);
-		lengthOfItems= getInt(b, offset+6, 1, MASK_8BITS);
+	public ExtendedEventDescriptor(final byte[] b, final TableSection parent) {
+		super(b, parent);
+		descriptorNumber = getInt(b, 2, 1, 0xF0)>>4;
+		lastDescriptorNumber = getInt(b, 2, 1, MASK_4BITS);
+		iso639LanguageCode = getISO8859_1String(b, 3,3);
+		lengthOfItems= getInt(b, 6, 1, MASK_8BITS);
 
-		int t=offset+7;
-		while (t<(lengthOfItems+offset+7)) {
+		int t=7;
+		while (t<(lengthOfItems + 7)) {
 			final int item_description_length = getInt(b, t, 1, MASK_8BITS);
 			final DVBString item_descripton=new DVBString(b, t);
 			final int item_length = getInt(b, t+1+item_description_length, 1, MASK_8BITS);
@@ -111,16 +103,13 @@ public class ExtendedEventDescriptor extends LanguageDependentEitDescriptor{
 			t+=2+item_description_length+item_length;
 		}
 
-		text = new DVBString(b,offset+7 +lengthOfItems);
+		text = new DVBString(b, 7 +lengthOfItems);
 
 	}
 
+	@Override
 	public String getIso639LanguageCode() {
 		return iso639LanguageCode;
-	}
-
-	public void setIso639LanguageCode(final String networkName) {
-		this.iso639LanguageCode = networkName;
 	}
 
 	@Override
@@ -129,24 +118,23 @@ public class ExtendedEventDescriptor extends LanguageDependentEitDescriptor{
 	}
 
 	@Override
-	public DefaultMutableTreeNode getJTreeNode(final int modus){
-		final DefaultMutableTreeNode t = super.getJTreeNode(modus);
-		if(simpleModus(modus)){
-			t.add(new DefaultMutableTreeNode(new KVP("ISO_639_language_code",iso639LanguageCode ,null)));
-			addListJTree(t,itemList, modus, "items");
-			if(text.getLength()>0){
-				t.add(new DefaultMutableTreeNode(new KVP("text",text,null)));
+	public KVP getJTreeNode(final int modus) {
+		final KVP t = super.getJTreeNode(modus);
+		if (simpleModus(modus)) {
+			t.add(new KVP("ISO_639_language_code", iso639LanguageCode));
+			addListJTree(t, itemList, modus, "items");
+			if (text.getLength() > 0) {
+				t.add(new KVP("text", text));
 			}
-		}else{
-
-			t.add(new DefaultMutableTreeNode(new KVP("descriptor_number",descriptorNumber ,null)));
-			t.add(new DefaultMutableTreeNode(new KVP("last_descriptor_number",lastDescriptorNumber ,null)));
-			t.add(new DefaultMutableTreeNode(new KVP("ISO_639_language_code",iso639LanguageCode ,null)));
-			t.add(new DefaultMutableTreeNode(new KVP("length_of_items",lengthOfItems,null)));
-			addListJTree(t,itemList, modus, "items");
-			t.add(new DefaultMutableTreeNode(new KVP("text_encoding",text.getEncodingString(),null)));
-			t.add(new DefaultMutableTreeNode(new KVP("text_length",text.getLength(),null)));
-			t.add(new DefaultMutableTreeNode(new KVP("text",text,null)));
+		} else {
+			t.add(new KVP("descriptor_number", descriptorNumber));
+			t.add(new KVP("last_descriptor_number", lastDescriptorNumber));
+			t.add(new KVP("ISO_639_language_code", iso639LanguageCode));
+			t.add(new KVP("length_of_items", lengthOfItems));
+			addListJTree(t, itemList, modus, "items");
+			t.add(new KVP("text_encoding", text.getEncodingString()));
+			t.add(new KVP("text_length", text.getLength()));
+			t.add(new KVP("text", text));
 		}
 
 		return t;

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/ExtendedEventDescriptor.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/ExtendedEventDescriptor.java
@@ -39,23 +39,7 @@ import nl.digitalekabeltelevisie.data.mpeg.psi.TableSection;
 
 public class ExtendedEventDescriptor extends LanguageDependentEitDescriptor{
 
-	public static class Item implements TreeNode{
-		private DVBString itemDescription;
-		private DVBString item;
-
-
-		public Item(final DVBString itemDescription, final DVBString item) {
-			super();
-			this.itemDescription = itemDescription;
-			this.item = item;
-		}
-		public DVBString getItem() {
-			return item;
-		}
-		public DVBString getItemDescription() {
-			return itemDescription;
-		}
-
+	public static record Item(DVBString itemDescription, DVBString item) implements TreeNode{
 		@Override
 		public KVP getJTreeNode(final int modus) {
 			KVP s;
@@ -63,11 +47,7 @@ public class ExtendedEventDescriptor extends LanguageDependentEitDescriptor{
 				s = new KVP("item", itemDescription + ": " + item, null);
 			} else {
 				s = new KVP("item");
-				s.add(new KVP("item_description_encoding", itemDescription.getEncodingString()));
-				s.add(new KVP("item_description_length", itemDescription.getLength()));
 				s.add(new KVP("item_description", itemDescription));
-				s.add(new KVP("item_encoding", item.getEncodingString()));
-				s.add(new KVP("item_length", item.getLength()));
 				s.add(new KVP("item", item));
 			}
 
@@ -132,8 +112,6 @@ public class ExtendedEventDescriptor extends LanguageDependentEitDescriptor{
 			t.add(new KVP("ISO_639_language_code", iso639LanguageCode));
 			t.add(new KVP("length_of_items", lengthOfItems));
 			addListJTree(t, itemList, modus, "items");
-			t.add(new KVP("text_encoding", text.getEncodingString()));
-			t.add(new KVP("text_length", text.getLength()));
 			t.add(new KVP("text", text));
 		}
 

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/ExtensionDescriptor.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/ExtensionDescriptor.java
@@ -2,7 +2,7 @@
  *
  *  http://www.digitalekabeltelevisie.nl/dvb_inspector
  *
- *  This code is Copyright 2009-2015 by Eric Berendsen (e_berendsen@digitalekabeltelevisie.nl)
+ *  This code is Copyright 2009-2024 by Eric Berendsen (e_berendsen@digitalekabeltelevisie.nl)
  *
  *  This file is part of DVB Inspector.
  *
@@ -39,22 +39,26 @@ public abstract class ExtensionDescriptor extends Descriptor {
 	protected final int descriptor_tag_extension;
 	protected final byte[] selector_byte;
 
-	public ExtensionDescriptor(final byte[] b, final int offset, final TableSection parent) {
-		super(b, offset,parent);
-		descriptor_tag_extension = getInt(b, privateDataOffset++, 1, MASK_8BITS);
-		selector_byte=getBytes(b, privateDataOffset, descriptorLength-1);
+	public ExtensionDescriptor(byte[] b, TableSection parent) {
+		super(b, parent);
+		descriptor_tag_extension = getInt(b, PRIVATE_DATA_OFFSET, 1, MASK_8BITS);
+		selector_byte=getBytes(b, PRIVATE_DATA_OFFSET + 1, descriptorLength-1);
 	}
 
+	/**
+	 * This will always return a KVP, but to not break interface it still is declared as DefaultMutableTreeNode
+	 */
 	@Override
-	public DefaultMutableTreeNode getJTreeNode(final int modus){
+	public DefaultMutableTreeNode getJTreeNode(int modus){
 
-		final DefaultMutableTreeNode t = super.getJTreeNode(modus);
-		t.add(new DefaultMutableTreeNode(new KVP("descriptor_tag_extension",descriptor_tag_extension,getDescriptorTagString())));
-		t.add(new DefaultMutableTreeNode(new KVP("selector_byte",selector_byte,null)));
+		KVP t = (KVP) super.getJTreeNode(modus);
+		t.add(new KVP("descriptor_tag_extension",descriptor_tag_extension).setDescription(getDescriptorTagString()));
+		t.add(new KVP("selector_byte",selector_byte));
 
 		return t;
 	}
 
+	@Override
 	public String getDescriptorname() {
 		return getDescriptorname(descriptorTag, parentTableSection)+" ("+getDescriptorTagString()+")";
 	}

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/LanguageDependentEitDescriptor.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/LanguageDependentEitDescriptor.java
@@ -27,6 +27,7 @@
 
 package nl.digitalekabeltelevisie.data.mpeg.descriptors;
 
+import nl.digitalekabeltelevisie.controller.KVP;
 import nl.digitalekabeltelevisie.data.mpeg.psi.TableSection;
 
 /**
@@ -39,10 +40,15 @@ import nl.digitalekabeltelevisie.data.mpeg.psi.TableSection;
  */
 public abstract class LanguageDependentEitDescriptor extends Descriptor{
 	
-	public LanguageDependentEitDescriptor(byte[] b, int offset, TableSection parent) {
-		super(b, offset, parent);
+	public LanguageDependentEitDescriptor(byte[] b, TableSection parent) {
+		super(b,  parent);
 	}
 
+
+	@Override
+	public KVP getJTreeNode(final int modus){
+		return (KVP) super.getJTreeNode(modus);
+	}
 
 	public abstract String getIso639LanguageCode();
 

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/LinkageDescriptor.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/LinkageDescriptor.java
@@ -96,7 +96,7 @@ public class LinkageDescriptor extends Descriptor {
 		public KVP getJTreeNode(final int modus) {
 			final KVP s = new KVP("platform_name");
 			s.add(new KVP("ISO_639_language_code", iso639LanguageCode));
-			s.add(new KVP("platform_name", platformName, null));
+			s.add(new KVP("platform_name", platformName));
 			return s;
 		}
 	}

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/LinkageDescriptor.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/LinkageDescriptor.java
@@ -53,30 +53,18 @@ public class LinkageDescriptor extends Descriptor {
 	private List<NordigBootLoader> bootLoaderList = new ArrayList<>();
 	private List<BrandHomeTransponder> m7BrandHomeTransponderList = new ArrayList<>();
 
-	public static class OUIEntry implements TreeNode{
+	public static record OUIEntry(int oui, int selectorLength, byte[] selectorByte) implements TreeNode{
 
-		private final int oui;
-		private final int selectorLength;
-		private final byte[] selectorByte;
-
-
-		public OUIEntry(final int oui, final int selectorLength, final byte[] selectorByte) {
-			super();
-			this.oui = oui;
-			this.selectorLength = selectorLength;
-			this.selectorByte = selectorByte;
-		}
-
-		public DefaultMutableTreeNode getJTreeNode(final int modus){
-			final DefaultMutableTreeNode s=new DefaultMutableTreeNode(new KVP("OUI"));
-			s.add(new DefaultMutableTreeNode(new KVP("oui",oui,Utils.getOUIString(oui))));
-			s.add(new DefaultMutableTreeNode(new KVP("selector_length",selectorLength,null)));
-			s.add(new DefaultMutableTreeNode(new KVP("selector_bytes",selectorByte,null)));
+		@Override
+		public KVP getJTreeNode(final int modus) {
+			final KVP s = new KVP("OUI");
+			s.add(new KVP("oui", oui).setDescription(getOUIString(oui)));
+			s.add(new KVP("selector_length", selectorLength));
+			s.add(new KVP("selector_bytes", selectorByte));
 			return s;
 		}
 
 	}
-
 
 	public static class Platform implements TreeNode{
 		/**
@@ -93,61 +81,35 @@ public class LinkageDescriptor extends Descriptor {
 		}
 
 
-		public DefaultMutableTreeNode getJTreeNode(final int modus){
-			final DefaultMutableTreeNode s=new DefaultMutableTreeNode(new KVP("platforms"));
-			s.add(new DefaultMutableTreeNode(new KVP("platform_id",platformId,getPlatformIDString(platformId))));
+		@Override
+		public KVP getJTreeNode(final int modus){
+			final KVP s= new KVP("platforms");
+			s.add(new KVP("platform_id",platformId).setDescription(getPlatformIDString(platformId)));
 			addListJTree(s,platformNameList,modus,"platform_name_loop");
 			return s;
 		}
 	}
 
-	public static class PlatformName implements TreeNode{
+	public static record PlatformName(String iso639LanguageCode, DVBString platformName) implements TreeNode {
 
-		private final String iso639LanguageCode;
-		private final DVBString platformName;
-
-		public PlatformName(final String lCode, final DVBString pName){
-			iso639LanguageCode = lCode;
-			platformName = pName;
-		}
-
-		public DefaultMutableTreeNode getJTreeNode(final int modus){
-			final DefaultMutableTreeNode s=new DefaultMutableTreeNode(new KVP("platform_name"));
-			s.add(new DefaultMutableTreeNode(new KVP("ISO_639_language_code",iso639LanguageCode,null)));
-			s.add(new DefaultMutableTreeNode(new KVP("platform_name_length",platformName.getLength() ,null)));
-			s.add(new DefaultMutableTreeNode(new KVP("platform_name",platformName ,null)));
+		@Override
+		public KVP getJTreeNode(final int modus) {
+			final KVP s = new KVP("platform_name");
+			s.add(new KVP("ISO_639_language_code", iso639LanguageCode));
+			s.add(new KVP("platform_name", platformName, null));
 			return s;
 		}
 	}
 
-	public static class NordigBootLoader implements TreeNode{
+	public static record NordigBootLoader(int manufacturer_id, byte[] version_id, long private_id, byte[] start_time) implements TreeNode{
 
-		/**
-		 * @param manufacturer_id
-		 * @param version_id
-		 * @param private_id
-		 * @param start_time
-		 */
-		private NordigBootLoader(int manufacturer_id, byte[] version_id,
-				long private_id, byte[] start_time) {
-			super();
-			this.manufacturer_id = manufacturer_id;
-			this.version_id = version_id;
-			this.private_id = private_id;
-			this.start_time = start_time;
-		}
-
-		private final int manufacturer_id;
-		private final byte[] version_id; // 64 bits, 8 bytes
-		private final long private_id;
-		private final byte[] start_time;
-
-		public DefaultMutableTreeNode getJTreeNode(final int modus){
-			final DefaultMutableTreeNode s=new DefaultMutableTreeNode(new KVP("bootloader"));
-			s.add(new DefaultMutableTreeNode(new KVP("manufacturer_id",manufacturer_id,null)));
-			s.add(new DefaultMutableTreeNode(new KVP("version_id",version_id,null)));
-			s.add(new DefaultMutableTreeNode(new KVP("private_id",private_id,null)));
-			s.add(new DefaultMutableTreeNode(new KVP("start_time",start_time,Utils.getUTCFormattedString(start_time))));
+		@Override
+		public KVP getJTreeNode(final int modus){
+			final KVP s=new KVP("bootloader");
+			s.add(new KVP("manufacturer_id",manufacturer_id));
+			s.add(new KVP("version_id",version_id));
+			s.add(new KVP("private_id",private_id));
+			s.add(new KVP("start_time",start_time).setDescription(getUTCFormattedString(start_time)));
 			return s;
 		}
 	}
@@ -163,106 +125,38 @@ public class LinkageDescriptor extends Descriptor {
 			essential_font_download_flag = (fontInfo & 0b1000_0000) >>7;
 			font_id = fontInfo & 0b0111_1111;
 		}
-		
 
 		@Override
-		public DefaultMutableTreeNode getJTreeNode(int modus) {
-			final DefaultMutableTreeNode s=new DefaultMutableTreeNode(new KVP("Donwloadable Font"));
-			s.add(new DefaultMutableTreeNode(new KVP("essential_font_download_flag",essential_font_download_flag,essential_font_download_flag==1?"font is required to present these subtitles":"font is a supplementary font")));
-			s.add(new DefaultMutableTreeNode(new KVP("font_id",font_id,null)));
+		public KVP getJTreeNode(int modus) {
+			final KVP s = new KVP("Donwloadable Font");
+			s.add(new KVP("essential_font_download_flag", essential_font_download_flag).setDescription(
+					essential_font_download_flag == 1 ? "font is required to present these subtitles" : "font is a supplementary font"));
+			s.add(new KVP("font_id", font_id));
 			return s;
 		}
-		
+
 	}
 	
-	public class BrandHomeTransponder implements TreeNode{
-		
-		public BrandHomeTransponder(int operator_network_id, int operator_sublist_id, int home_transport_stream_id,
-				int home_original_network_id, int homebckp_transport_stream_id, int homebckp_original_network_id,
-				int fst_pid, int fst_version_number, int reserved) {
-			super();
-			this.operator_network_id = operator_network_id;
-			this.operator_sublist_id = operator_sublist_id;
-			this.home_transport_stream_id = home_transport_stream_id;
-			this.home_original_network_id = home_original_network_id;
-			this.homebckp_transport_stream_id = homebckp_transport_stream_id;
-			this.homebckp_original_network_id = homebckp_original_network_id;
-			this.fst_pid = fst_pid;
-			this.fst_version_number = fst_version_number;
-			this.reserved = reserved;
-		}
-
-
-		int operator_network_id;
-		int operator_sublist_id;
-		int home_transport_stream_id;
-		int home_original_network_id;
-		int homebckp_transport_stream_id;
-		int homebckp_original_network_id;
-		int fst_pid;
-		int fst_version_number;
-		int reserved;
-		
+	public record BrandHomeTransponder(int operator_network_id, int operator_sublist_id, int home_transport_stream_id, int home_original_network_id,
+			int homebckp_transport_stream_id, int homebckp_original_network_id, int fst_pid, int fst_version_number, int reserved)
+			implements TreeNode {
 
 		@Override
-		public DefaultMutableTreeNode getJTreeNode(int modus) {
-			final DefaultMutableTreeNode s=new DefaultMutableTreeNode(new KVP("M7BrandHomeTransponder"));
-			s.add(new DefaultMutableTreeNode(new KVP("operator_network_id",operator_network_id,null)));
-			s.add(new DefaultMutableTreeNode(new KVP("operator_sublist_id",operator_sublist_id,null)));
-			s.add(new DefaultMutableTreeNode(new KVP("home_transport_stream_id",home_transport_stream_id,null)));
-			s.add(new DefaultMutableTreeNode(new KVP("home_original_network_id",home_original_network_id,null)));
-			s.add(new DefaultMutableTreeNode(new KVP("homebckp_transport_stream_id",homebckp_transport_stream_id,null)));
-			s.add(new DefaultMutableTreeNode(new KVP("homebckp_original_network_id",homebckp_original_network_id,null)));
-			s.add(new DefaultMutableTreeNode(new KVP("fst_pid",fst_pid,null)));
-			s.add(new DefaultMutableTreeNode(new KVP("FST_version_number",fst_version_number,null)));
-			s.add(new DefaultMutableTreeNode(new KVP("reserved",reserved,null)));
+		public KVP getJTreeNode(int modus) {
+			final KVP s = new KVP("M7BrandHomeTransponder");
+			s.add(new KVP("operator_network_id", operator_network_id));
+			s.add(new KVP("operator_sublist_id", operator_sublist_id));
+			s.add(new KVP("home_transport_stream_id", home_transport_stream_id));
+			s.add(new KVP("home_original_network_id", home_original_network_id));
+			s.add(new KVP("homebckp_transport_stream_id", homebckp_transport_stream_id));
+			s.add(new KVP("homebckp_original_network_id", homebckp_original_network_id));
+			s.add(new KVP("fst_pid", fst_pid));
+			s.add(new KVP("FST_version_number", fst_version_number));
+			s.add(new KVP("reserved", reserved));
 			return s;
 		}
 
 
-		public int getOperator_network_id() {
-			return operator_network_id;
-		}
-
-
-		public int getOperator_sublist_id() {
-			return operator_sublist_id;
-		}
-
-
-		public int getHome_transport_stream_id() {
-			return home_transport_stream_id;
-		}
-
-
-		public int getHome_original_network_id() {
-			return home_original_network_id;
-		}
-
-
-		public int getHomebckp_transport_stream_id() {
-			return homebckp_transport_stream_id;
-		}
-
-
-		public int getHomebckp_original_network_id() {
-			return homebckp_original_network_id;
-		}
-
-
-		public int getFst_pid() {
-			return fst_pid;
-		}
-
-
-		public int getFst_version_number() {
-			return fst_version_number;
-		}
-
-
-		public int getReserved() {
-			return reserved;
-		}
 	}
 
 	private int transportStreamId;
@@ -308,118 +202,118 @@ public class LinkageDescriptor extends Descriptor {
 	// linkage type=09 is software update, oui = http://standards.ieee.org/regauth/oui/oui.txt
 
 
-	public LinkageDescriptor(final byte[] b, final int offset, final TableSection parent) {
-		super(b, offset,parent);
-		transportStreamId = getInt(b,offset+2,2,MASK_16BITS);
-		originalNetworkId = getInt(b,offset+4,2,MASK_16BITS);
-		serviceId =  getInt(b,offset+6,2,MASK_16BITS);
-		linkageType = getInt(b,offset+8,1,MASK_8BITS);
+	public LinkageDescriptor(byte[] b, TableSection parent) {
+		super(b, parent);
+		transportStreamId = getInt(b, 2,2,MASK_16BITS);
+		originalNetworkId = getInt(b, 4,2,MASK_16BITS);
+		serviceId =  getInt(b, 6,2,MASK_16BITS);
+		linkageType = getInt(b, 8,1,MASK_8BITS);
 		if(linkageType==0x08){ // mobile hand-over
 			int r =0;
-			hand_over_type = getInt(b,offset+9,1,0xF0)>>>4;
-			origin_type = getInt(b,offset+9,1,MASK_1BIT);
+			hand_over_type = getInt(b, 9,1,0xF0)>>>4;
+			origin_type = getInt(b, 9,1,MASK_1BIT);
 			if((hand_over_type ==0x01)
 					|| (hand_over_type ==0x02)
 					|| (hand_over_type ==0x03)){
-				network_id = getInt(b,offset+10,2,MASK_16BITS);
+				network_id = getInt(b, 10,2,MASK_16BITS);
 				r+=2;
 			}
 			if (origin_type ==0x00){
-				initial_service_id = getInt(b,offset+10+r,2,MASK_16BITS);
+				initial_service_id = getInt(b, 10+r,2,MASK_16BITS);
 				r+=2;
 			}
-			privateDataByte = copyOfRange(b, offset+10+r, offset+descriptorLength+2);
+			privateDataByte = copyOfRange(b,  10+r,  descriptorLength+2);
 		}else if(linkageType==0x09){ //System Software Update Service (TS 102 006)
-			OUI_data_length = getInt(b,offset+9,1,MASK_8BITS);
+			OUI_data_length = getInt(b, 9,1,MASK_8BITS);
 			int r =0;
 			while (r<OUI_data_length) {
-				final int oui = getInt(b,offset+ 10+r, 3, Utils.MASK_24BITS);
-				final int selectorLength= getInt(b, offset+r+13, 1, MASK_8BITS);
-				final byte[] selector_byte = copyOfRange(b, offset+r+14, offset+r+14+selectorLength);
+				final int oui = getInt(b,  10+r, 3, Utils.MASK_24BITS);
+				final int selectorLength= getInt(b,  r+13, 1, MASK_8BITS);
+				final byte[] selector_byte = copyOfRange(b,  r+14,  r+14+selectorLength);
 
 				final OUIEntry ouiEntry = new OUIEntry(oui,selectorLength,selector_byte);
 				ouiList.add(ouiEntry);
 				r=r+4+selectorLength;
 			}
-			privateDataByte = copyOfRange(b, offset+10+r, offset+descriptorLength+2);
+			privateDataByte = copyOfRange(b,  10+r,  descriptorLength+2);
 		}else if(linkageType==0x0a){ // TS containing SSU BAT or NIT (TS 102 006)
-			tableType =	getInt(b,offset+9,1,MASK_8BITS);
-			privateDataByte = copyOfRange(b, offset+10, offset+descriptorLength+2);
+			tableType =	getInt(b, 9,1,MASK_8BITS);
+			privateDataByte = copyOfRange(b,  10,  descriptorLength+2);
 		}else if(linkageType==0x0b){ // IP/MAC Notification Table
-			platformIdDataLength =	getInt(b,offset+9,1,MASK_8BITS);
+			platformIdDataLength =	getInt(b, 9,1,MASK_8BITS);
 			int r =0;
 			while (r<platformIdDataLength) {
-				final int platform_id = getInt(b,offset+ 10+r, 3, Utils.MASK_24BITS);
+				final int platform_id = getInt(b,  10+r, 3, Utils.MASK_24BITS);
 				final Platform p = new Platform(platform_id);
 				platformList.add(p);
-				final int platform_name_loop_length= getInt(b, offset+r+13, 1, MASK_8BITS);
+				final int platform_name_loop_length= getInt(b,  r+13, 1, MASK_8BITS);
 				int t=0;
 				while(t<platform_name_loop_length){
-					final String languageCode=getISO8859_1String(b, offset+r+t+14, 3);
-					final DVBString platformName = new DVBString(b,offset+r+t+17);
+					final String languageCode=getISO8859_1String(b,  r+t+14, 3);
+					final DVBString platformName = new DVBString(b, r+t+17);
 					final PlatformName pName = new PlatformName(languageCode, platformName);
 					p.addPlatformName(pName);
 					t+=4+platformName.getLength();
 				}
 				r+=t+4;
 			}
-			privateDataByte = Arrays.copyOfRange(b, offset+10+r, offset+descriptorLength+2);
+			privateDataByte = Arrays.copyOfRange(b,  10+r,  descriptorLength+2);
 		}else if(linkageType==0x0c){ // TS containing SSU BAT or NIT (TS 102 006)
-			tableType =	getInt(b,offset+9,1,MASK_8BITS);
+			tableType =	getInt(b, 9,1,MASK_8BITS);
 			if(tableType==0x02){
-				bouquetID = getInt(b,offset+10,2,MASK_16BITS);
-				privateDataByte = copyOfRange(b, offset+12, offset+descriptorLength+2);
+				bouquetID = getInt(b, 10,2,MASK_16BITS);
+				privateDataByte = copyOfRange(b,  12,  descriptorLength+2);
 			}else{
-				privateDataByte = copyOfRange(b, offset+10, offset+descriptorLength+2);
+				privateDataByte = copyOfRange(b,  10,  descriptorLength+2);
 			}
 
 		}else if(linkageType==0x0D){ // event linkage
-			target_event_id  = getInt(b,offset+9,2,MASK_16BITS);
-			target_listed = getInt(b,offset+11,1,0x80)>>7;
-			event_simulcast= getInt(b,offset+11,1,0x40)>>6;
-			reserved = getInt(b,offset+11,1,MASK_6BITS);
-			privateDataByte = copyOfRange(b, offset+12, offset+descriptorLength+2);
+			target_event_id  = getInt(b, 9,2,MASK_16BITS);
+			target_listed = getInt(b, 11,1,0x80)>>7;
+			event_simulcast= getInt(b, 11,1,0x40)>>6;
+			reserved = getInt(b, 11,1,MASK_6BITS);
+			privateDataByte = copyOfRange(b,  12,  descriptorLength+2);
 
 		}else if(linkageType>=0x0e && linkageType<=0x1f){ // extended event linkage 
 			logger.info("extended event linkage not implemented");
 		}else if(linkageType==0x20){ // downloadable font info linkage
-			font_count = getInt(b,offset+9,1,MASK_8BITS);
+			font_count = getInt(b, 9,1,MASK_8BITS);
 			for (int i = 0; i < font_count; i++) {
-				FontInfo font = new FontInfo(getInt(b,offset+10+i,1,MASK_8BITS));
+				FontInfo font = new FontInfo(getInt(b, 10+i,1,MASK_8BITS));
 				fontList.add(font);
 			}
-			privateDataByte = copyOfRange(b, offset + 10 + font_count, offset + descriptorLength + 2);
+			privateDataByte = copyOfRange(b,   10 + font_count, descriptorLength + 2);
 
 		}else if(linkageType==0x81){ //  NorDig Unified ver 2.1    ch 12.2.6 NorDig linkage for bootloader
 			// TODO, this is a private usage, but not indicated by a private_data_specifier_descriptor: 0x5F
 			// just assume it is nordig?
 			int s = 9; // private data, if any, starts at position 9
 			while((s+17) <= descriptorLength){ // bootloader = 19 bytes
-				int manufacturer_id = getInt(b,offset+s,2,MASK_16BITS);
-				byte[] version_id = copyOfRange(b, offset+s+2, offset+s+10); // 64 bits, 8 bytes
-				long private_id = getLong(b, offset+s+10, 4, MASK_32BITS);
-				byte[] start_time =  copyOfRange(b, offset+s+14, offset+s+19);
+				int manufacturer_id = getInt(b, s,2,MASK_16BITS);
+				byte[] version_id = copyOfRange(b,  s+2,  s+10); // 64 bits, 8 bytes
+				long private_id = getLong(b,  s+10, 4, MASK_32BITS);
+				byte[] start_time =  copyOfRange(b,  s+14,  s+19);
 				final NordigBootLoader nordigBootLoader = new NordigBootLoader(manufacturer_id, version_id, private_id, start_time);
 				bootLoaderList.add(nordigBootLoader);
 				s +=19;
 			}
-			privateDataByte = copyOfRange(b, offset+s, offset+descriptorLength+2);
+			privateDataByte = copyOfRange(b,  s,  descriptorLength+2);
 			
 			// M7 FASTSCAN HOME TP LOCATION DESCRIPTOR
 		} else if (((linkageType == 0x88) || (linkageType == 0x89) || (linkageType == 0x8A))
 				&& PreferencesManager.isEnableM7Fastscan()) {
-			m7_code = getInt(b,offset+9,2,MASK_16BITS);
+			m7_code = getInt(b, 9,2,MASK_16BITS);
 			int s = 11;
 			while((s+9) <= descriptorLength){
-				int operator_network_id = getInt(b,offset+s,2,MASK_16BITS);
-				int operator_sublist_id = getInt(b,offset+s+2,1,MASK_8BITS);
-				int home_transport_stream_id = getInt(b,offset+s+3,2,MASK_16BITS);
-				int home_original_network_id = getInt(b,offset+s+5,2,MASK_16BITS);
-				int homebckp_transport_stream_id = getInt(b,offset+s+7,2,MASK_16BITS);
-				int homebckp_original_network_id = getInt(b,offset+s+9,2,MASK_16BITS);
-				int fst_pid = getInt(b,offset+s+11,2,MASK_16BITS);   
-				int fst_version_number = getInt(b,offset+s+13,1,0xF8)>>>3;   
-				int reserved = getInt(b,offset+s+13,1,MASK_3BITS);   
+				int operator_network_id = getInt(b, s,2,MASK_16BITS);
+				int operator_sublist_id = getInt(b, s+2,1,MASK_8BITS);
+				int home_transport_stream_id = getInt(b, s+3,2,MASK_16BITS);
+				int home_original_network_id = getInt(b, s+5,2,MASK_16BITS);
+				int homebckp_transport_stream_id = getInt(b, s+7,2,MASK_16BITS);
+				int homebckp_original_network_id = getInt(b, s+9,2,MASK_16BITS);
+				int fst_pid = getInt(b, s+11,2,MASK_16BITS);   
+				int fst_version_number = getInt(b, s+13,1,0xF8)>>>3;   
+				int reserved = getInt(b, s+13,1,MASK_3BITS);   
 			
 				BrandHomeTransponder brandHomeTransponder = new BrandHomeTransponder(operator_network_id, operator_sublist_id,
 						home_transport_stream_id,home_original_network_id,homebckp_transport_stream_id,homebckp_original_network_id,
@@ -428,19 +322,19 @@ public class LinkageDescriptor extends Descriptor {
 				s+=14;
 			}
 			
-			privateDataByte = copyOfRange(b, offset+s, offset+descriptorLength+2);
+			privateDataByte = copyOfRange(b,  s,  descriptorLength+2);
 			
 			// M7 FASTSCAN ONT LOCATION DESCRIPTOR
 			
 		} else if ((linkageType == 0x8D)&& PreferencesManager.isEnableM7Fastscan()){ 
-			m7_code = getInt(b,offset+9,2,MASK_16BITS);
-			reserved = getInt(b,offset+11,1,MASK_8BITS);
-			privateDataByte = copyOfRange(b, offset+12, offset+descriptorLength+2);
+			m7_code = getInt(b, 9,2,MASK_16BITS);
+			reserved = getInt(b, 11,1,MASK_8BITS);
+			privateDataByte = copyOfRange(b,  12,  descriptorLength+2);
 		} else if (linkageType <= 0x07){ // no extra data
-			privateDataByte = copyOfRange(b, offset+9, offset+descriptorLength+2);
+			privateDataByte = copyOfRange(b,  9,  descriptorLength+2);
 		}else{
 			logger.log(Level.INFO,"LinkageDescriptor, not implemented linkageType: "+linkageType +"("+getLinkageTypeString(linkageType)+"), called from:"+parent);
-			privateDataByte = copyOfRange(b, offset+9, offset+descriptorLength+2);
+			privateDataByte = copyOfRange(b,  9,  descriptorLength+2);
 
 		}
 	}
@@ -453,60 +347,60 @@ public class LinkageDescriptor extends Descriptor {
 	@Override
 	public DefaultMutableTreeNode getJTreeNode(final int modus){
 		final DefaultMutableTreeNode t = super.getJTreeNode(modus);
-		t.add(new DefaultMutableTreeNode(new KVP("transport_stream_id",transportStreamId ,null)));
-		t.add(new DefaultMutableTreeNode(new KVP("original_network_id",originalNetworkId ,Utils.getOriginalNetworkIDString(originalNetworkId))));
-		t.add(new DefaultMutableTreeNode(new KVP("service_id",serviceId ,parentTableSection.getParentPID().getParentTransportStream().getPsi().getSdt().getServiceName(originalNetworkId,transportStreamId,serviceId))));
-		t.add(new DefaultMutableTreeNode(new KVP("linkage_type",linkageType ,getLinkageTypeString(linkageType))));
+		t.add(new KVP("transport_stream_id",transportStreamId));
+		t.add(new KVP("original_network_id",originalNetworkId).setDescription(getOriginalNetworkIDString(originalNetworkId)));
+		t.add(new KVP("service_id",serviceId).setDescription(parentTableSection.getParentPID().getParentTransportStream().getPsi().getSdt().getServiceName(originalNetworkId,transportStreamId,serviceId)));
+		t.add(new KVP("linkage_type",linkageType).setDescription(getLinkageTypeString(linkageType)));
 		if(linkageType==0x08){
-			t.add(new DefaultMutableTreeNode(new KVP("hand-over_type",hand_over_type ,getHandOverString(hand_over_type))));
-			t.add(new DefaultMutableTreeNode(new KVP("origin_type",origin_type ,getOriginTypeString(origin_type))));
+			t.add(new KVP("hand-over_type",hand_over_type).setDescription(getHandOverString(hand_over_type)));
+			t.add(new KVP("origin_type",origin_type).setDescription(getOriginTypeString(origin_type)));
 			if((hand_over_type ==0x01)
 					|| (hand_over_type ==0x02)
 					|| (hand_over_type ==0x03)){
-				t.add(new DefaultMutableTreeNode(new KVP("network_id",network_id ,getParentPID().getParentTransportStream().getPsi().getNit().getNetworkName(network_id))));
+				t.add(new KVP("network_id",network_id).setDescription(getParentPID().getParentTransportStream().getPsi().getNit().getNetworkName(network_id)));
 			}
 			if (origin_type ==0x00){
-				t.add(new DefaultMutableTreeNode(new KVP("initial_service_id",initial_service_id ,null)));
+				t.add(new KVP("initial_service_id",initial_service_id));
 			}
 
 		}else if(linkageType==0x09){
 			addListJTree(t,ouiList,modus,"Systems Software Update");
 		}else if(linkageType==0x0a){
-			t.add(new DefaultMutableTreeNode(new KVP("table_type",tableType ,getTableTypeString(tableType))));
+			t.add(new KVP("table_type",tableType).setDescription(getTableTypeString(tableType)));
 		}else if(linkageType==0x0b){
 			addListJTree(t,platformList,modus,"platform_list");
 		}else if(linkageType==0x0c){
-			t.add(new DefaultMutableTreeNode(new KVP("table_type",tableType ,getTableTypeString(tableType))));
+			t.add(new KVP("table_type",tableType).setDescription(getTableTypeString(tableType)));
 			if(tableType==0x02){
-				t.add(new DefaultMutableTreeNode(new KVP("bouquet_id",bouquetID ,null)));
+				t.add(new KVP("bouquet_id",bouquetID));
 			}
 		}else if(linkageType==0x0d){ // event linkage
-			t.add(new DefaultMutableTreeNode(new KVP("target_event_id",target_event_id ,null)));
-			t.add(new DefaultMutableTreeNode(new KVP("target_listed",target_listed ,target_listed==1?"service shall be included in SDT":"service may not be included in SDT")));
-			t.add(new DefaultMutableTreeNode(new KVP("event_simulcast",event_simulcast ,event_simulcast==1?"target and source are being simulcast":"events are offset in time")));
-			t.add(new DefaultMutableTreeNode(new KVP("reserved",reserved ,null)));
+			t.add(new KVP("target_event_id",target_event_id));
+			t.add(new KVP("target_listed",target_listed).setDescription(target_listed==1?"service shall be included in SDT":"service may not be included in SDT"));
+			t.add(new KVP("event_simulcast",event_simulcast).setDescription(event_simulcast==1?"target and source are being simulcast":"events are offset in time"));
+			t.add(new KVP("reserved",reserved));
 		}else if(linkageType>=0x0e && linkageType<=0x1f){ // extended event linkage 
-			t.add(new DefaultMutableTreeNode(GuiUtils.getNotImplementedKVP("extended event linkage")));
+			t.add(GuiUtils.getNotImplementedKVP("extended event linkage"));
 		}else if(linkageType==0x20){ // downloadable font info linkage
 			
-			t.add(new DefaultMutableTreeNode(new KVP("font_count",font_count ,null)));
+			t.add(new KVP("font_count",font_count));
 			addListJTree(t,fontList,modus,"(downloadable fonts");
-			t.add(new DefaultMutableTreeNode(new KVP("reserved_zero_future_use",privateDataByte ,null)));
+			t.add(new KVP("reserved_zero_future_use",privateDataByte));
 			
 		}else if(linkageType==0x81){
 			addListJTree(t,bootLoaderList,modus,"Nordig BootLoader");
 
 		} else if (((linkageType == 0x88) || (linkageType == 0x89) || (linkageType == 0x90))
 				&& PreferencesManager.isEnableM7Fastscan()) {
-			t.add(new DefaultMutableTreeNode(new KVP("m7_code",m7_code ,"should contain values from 0x7701 to 0x77FF")));
+			t.add(new KVP("m7_code",m7_code).setDescription("should contain values from 0x7701 to 0x77FF"));
 			addListJTree(t,m7BrandHomeTransponderList,modus,"M7 Brand-HomeTransponderList");
 
 
 		} else if ((linkageType == 0x8D)&& PreferencesManager.isEnableM7Fastscan()){ // ONT LOCATION DESCRIPTOR
-			t.add(new DefaultMutableTreeNode(new KVP("m7_code",m7_code ,"should contain values from 0x7701 to 0x77FF (service_id == ONT_PID)")));
-			t.add(new DefaultMutableTreeNode(new KVP("reserved",reserved ,null)));
+			t.add(new KVP("m7_code",m7_code).setDescription("should contain values from 0x7701 to 0x77FF (service_id == ONT_PID)"));
+			t.add(new KVP("reserved",reserved));
 		}else {
-			t.add(new DefaultMutableTreeNode(new KVP("private_data_byte",privateDataByte ,"unimplmented linkage type")));
+			t.add(new KVP("private_data_byte",privateDataByte).setDescription("unimplmented linkage type"));
 		}
 		return t;
 	}
@@ -516,24 +410,12 @@ public class LinkageDescriptor extends Descriptor {
 	}
 
 
-	public void setOriginalNetworkId(final int caPID) {
-		this.originalNetworkId = caPID;
-	}
-
 	public int getTransportStreamId() {
 		return transportStreamId;
 	}
 
-	public void setTransportStreamId(final int caSystemID) {
-		this.transportStreamId = caSystemID;
-	}
-
 	public byte[] getPrivateDataByte() {
 		return privateDataByte;
-	}
-
-	public void setPrivateDataByte(final byte[] privateDataByte) {
-		this.privateDataByte = privateDataByte;
 	}
 
 	public static String getLinkageTypeString(final int linkageType) {

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/MultilingualBouquetNameDescriptor.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/MultilingualBouquetNameDescriptor.java
@@ -40,66 +40,31 @@ import nl.digitalekabeltelevisie.util.Utils;
 
 public class MultilingualBouquetNameDescriptor extends Descriptor {
 
-	private final List<BouquetName> bouquetNameList = new ArrayList<BouquetName>();
+	private final List<BouquetName> bouquetNameList = new ArrayList<>();
 
 
-	public static class BouquetName implements TreeNode{
-		/**
-		 *
-		 */
-		private final String iso639LanguageCode;
-		private final DVBString bouquet_name ;
+	public static record BouquetName(String iso639LanguageCode, DVBString bouquet_name) implements TreeNode{
 
-
-
-
-		/**
-		 * @param languageCode
-		 * @param bouquet_name
-		 */
-		public BouquetName(String languageCode, DVBString bouquet_name) {
-			iso639LanguageCode = languageCode;
-			this.bouquet_name = bouquet_name;
-		}
-
-
-
-		public DefaultMutableTreeNode getJTreeNode(final int modus){
-			final DefaultMutableTreeNode s=new DefaultMutableTreeNode(new KVP("bouquet_name"));
-			s.add(new DefaultMutableTreeNode(new KVP("ISO_639_language_code",iso639LanguageCode,null)));
-			s.add(new DefaultMutableTreeNode(new KVP("network_name_encoding",bouquet_name.getEncodingString(),null)));
-			s.add(new DefaultMutableTreeNode(new KVP("network_name_length",bouquet_name.getLength(),null)));
-			s.add(new DefaultMutableTreeNode(new KVP("network_name",bouquet_name,null)));
+		@Override
+		public KVP getJTreeNode(final int modus){
+			final KVP s=new KVP("bouquet_name");
+			s.add(new KVP("ISO_639_language_code",iso639LanguageCode));
+			s.add(new KVP("network_name",bouquet_name));
 			return s;
 		}
 
-
-		@Override
-		public String toString(){
-			return "code:'"+iso639LanguageCode;
-		}
-
-		public String getIso639LanguageCode() {
-			return iso639LanguageCode;
-		}
-
-		public DVBString getBouquet_name() {
-			return bouquet_name;
-		}
-
-
 	}
 
-	public MultilingualBouquetNameDescriptor(final byte[] b, final int offset, final TableSection parent) {
-		super(b, offset,parent);
-		int t=offset+2;
-		while (t<(descriptorLength+offset+2)) {
-			final String languageCode=Utils.getISO8859_1String(b, t, 3);
-			int bouquet_name_length = Utils.getInt(b, t+3, 1, Utils.MASK_8BITS);;
-			DVBString bouquet_name = new DVBString(b, t+3);
+	public MultilingualBouquetNameDescriptor(final byte[] b, final TableSection parent) {
+		super(b, parent);
+		int t = 2;
+		while (t < (descriptorLength + 2)) {
+			final String languageCode = Utils.getISO8859_1String(b, t, 3);
+			int bouquet_name_length = Utils.getInt(b, t + 3, 1, Utils.MASK_8BITS);
+			DVBString bouquet_name = new DVBString(b, t + 3);
 			final BouquetName s = new BouquetName(languageCode, bouquet_name);
 			bouquetNameList.add(s);
-			t+=4+bouquet_name_length;
+			t += 4 + bouquet_name_length;
 		}
 	}
 

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/MultilingualNetworkNameDescriptor.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/MultilingualNetworkNameDescriptor.java
@@ -40,74 +40,31 @@ import nl.digitalekabeltelevisie.util.Utils;
 
 public class MultilingualNetworkNameDescriptor extends Descriptor {
 
-	private final List<NetworkName> networkNameList = new ArrayList<NetworkName>();
+	private final List<NetworkName> networkNameList = new ArrayList<>();
 
 
-	public static class NetworkName implements TreeNode{
-		/**
-		 *
-		 */
-		private final String iso639LanguageCode;
-		private final DVBString network_name ;
+	public static record NetworkName(String iso639LanguageCode, DVBString network_name) implements TreeNode{
 
-
-
-
-		/**
-		 * @param languageCode
-		 * @param service_provider_name2
-		 * @param service_name2
-		 */
-		public NetworkName(String languageCode, DVBString service_name2) {
-			iso639LanguageCode = languageCode;
-			network_name = service_name2;
-		}
-
-
-
-		public DefaultMutableTreeNode getJTreeNode(final int modus){
-			final DefaultMutableTreeNode s=new DefaultMutableTreeNode(new KVP("network_name"));
-			s.add(new DefaultMutableTreeNode(new KVP("ISO_639_language_code",iso639LanguageCode,null)));
-			s.add(new DefaultMutableTreeNode(new KVP("network_name_encoding",network_name.getEncodingString(),null)));
-			s.add(new DefaultMutableTreeNode(new KVP("network_name_length",network_name.getLength(),null)));
-			s.add(new DefaultMutableTreeNode(new KVP("network_name",network_name,null)));
+		@Override
+		public KVP getJTreeNode(final int modus){
+			final KVP s = new KVP("network_name");
+			s.add(new KVP("ISO_639_language_code",iso639LanguageCode));
+			s.add(new KVP("network_name",network_name));
 			return s;
 		}
 
-
-
-		@Override
-		public String toString(){
-			return "code:'"+iso639LanguageCode;
-		}
-
-
-		public String getIso639LanguageCode() {
-			return iso639LanguageCode;
-		}
-
-
-
-		public DVBString getNetwork_name() {
-			return network_name;
-		}
-
-
-
-
-
 	}
 
-	public MultilingualNetworkNameDescriptor(final byte[] b, final int offset, final TableSection parent) {
-		super(b, offset,parent);
-		int t=offset+2;
-		while (t<(descriptorLength+offset+2)) {
-			final String languageCode=Utils.getISO8859_1String(b, t, 3);
-			int network_name_length = Utils.getInt(b, t+3, 1, Utils.MASK_8BITS);;
-			DVBString network_name = new DVBString(b, t+3);
+	public MultilingualNetworkNameDescriptor(final byte[] b, final TableSection parent) {
+		super(b, parent);
+		int t = 2;
+		while (t < (descriptorLength + 2)) {
+			final String languageCode = Utils.getISO8859_1String(b, t, 3);
+			int network_name_length = Utils.getInt(b, t + 3, 1, Utils.MASK_8BITS);
+			DVBString network_name = new DVBString(b, t + 3);
 			final NetworkName s = new NetworkName(languageCode, network_name);
 			networkNameList.add(s);
-			t+=4+network_name_length;
+			t += 4 + network_name_length;
 		}
 	}
 
@@ -117,8 +74,6 @@ public class MultilingualNetworkNameDescriptor extends Descriptor {
 		for (NetworkName serviceName : networkNameList) {
 			buf.append(serviceName.toString());
 		}
-
-
 		return buf.toString();
 	}
 

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/MultilingualServiceNameDescriptor.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/MultilingualServiceNameDescriptor.java
@@ -40,87 +40,33 @@ import nl.digitalekabeltelevisie.util.Utils;
 
 public class MultilingualServiceNameDescriptor extends Descriptor {
 
-	private final List<ServiceName> serviceNameList = new ArrayList<ServiceName>();
+	private final List<ServiceName> serviceNameList = new ArrayList<>();
 
 
-	public static class ServiceName implements TreeNode{
-		/**
-		 *
-		 */
-		private final String iso639LanguageCode;
-		private final DVBString service_provider_name ;
-		private final DVBString service_name ;
-
-
-
-
-		/**
-		 * @param languageCode
-		 * @param service_provider_name2
-		 * @param service_name2
-		 */
-		public ServiceName(String languageCode, DVBString service_provider_name2, DVBString service_name2) {
-			iso639LanguageCode = languageCode;
-			service_provider_name = service_provider_name2;
-			service_name = service_name2;
-		}
-
-
-
-		public DefaultMutableTreeNode getJTreeNode(final int modus){
-			final DefaultMutableTreeNode s=new DefaultMutableTreeNode(new KVP("service_name"));
-			s.add(new DefaultMutableTreeNode(new KVP("ISO_639_language_code",iso639LanguageCode,null)));
-			s.add(new DefaultMutableTreeNode(new KVP("service_provider_name_encoding",service_provider_name.getEncodingString(),null)));
-			s.add(new DefaultMutableTreeNode(new KVP("service_provider_name_length",service_provider_name.getLength(),null)));
-			s.add(new DefaultMutableTreeNode(new KVP("service_provider_name",service_provider_name,null)));
-			s.add(new DefaultMutableTreeNode(new KVP("service_name_encoding",service_name.getEncodingString(),null)));
-			s.add(new DefaultMutableTreeNode(new KVP("service_name_length",service_name.getLength(),null)));
-			s.add(new DefaultMutableTreeNode(new KVP("service_name",service_name,null)));
+	public static record ServiceName(String iso639LanguageCode, DVBString service_provider_name, DVBString service_name) implements TreeNode{
+		@Override
+		public KVP getJTreeNode(final int modus) {
+			final KVP s = new KVP("service_name");
+			s.add(new KVP("ISO_639_language_code", iso639LanguageCode));
+			s.add(new KVP("service_provider_name", service_provider_name));
+			s.add(new KVP("service_name", service_name));
 			return s;
 		}
 
-
-
-		@Override
-		public String toString(){
-			return "code:'"+iso639LanguageCode;
-		}
-
-
-		public String getIso639LanguageCode() {
-			return iso639LanguageCode;
-		}
-
-
-
-		public DVBString getService_provider_name() {
-			return service_provider_name;
-		}
-
-
-
-		public DVBString getService_name() {
-			return service_name;
-		}
-
-
-
-
-
 	}
 
-	public MultilingualServiceNameDescriptor(final byte[] b, final int offset, final TableSection parent) {
-		super(b, offset,parent);
-		int t=offset+2;
-		while (t<(descriptorLength+offset+2)) {
-			final String languageCode=Utils.getISO8859_1String(b, t, 3);
-			int service_provider_name_length = Utils.getInt(b, t+3, 1, Utils.MASK_8BITS);;
-			DVBString service_provider_name = new DVBString(b, t+3);
-			int service_name_length = Utils.getInt(b, t+4+service_provider_name_length, 1, Utils.MASK_8BITS);;
-			DVBString service_name = new DVBString(b, t+4+service_provider_name_length);
-			final ServiceName s = new ServiceName(languageCode, service_provider_name,service_name);
+	public MultilingualServiceNameDescriptor(final byte[] b, final TableSection parent) {
+		super(b, parent);
+		int t = 2;
+		while (t < (descriptorLength + 2)) {
+			final String languageCode = Utils.getISO8859_1String(b, t, 3);
+			int service_provider_name_length = Utils.getInt(b, t + 3, 1, Utils.MASK_8BITS);
+			DVBString service_provider_name = new DVBString(b, t + 3);
+			int service_name_length = Utils.getInt(b, t + 4 + service_provider_name_length, 1, Utils.MASK_8BITS);
+			DVBString service_name = new DVBString(b, t + 4 + service_provider_name_length);
+			final ServiceName s = new ServiceName(languageCode, service_provider_name, service_name);
 			serviceNameList.add(s);
-			t+=5+service_provider_name_length+service_name_length;
+			t += 5 + service_provider_name_length + service_name_length;
 		}
 	}
 

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/NetworkNameDescriptor.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/NetworkNameDescriptor.java
@@ -56,9 +56,7 @@ public class NetworkNameDescriptor extends Descriptor {
 	@Override
 	public DefaultMutableTreeNode getJTreeNode(final int modus){
 		final DefaultMutableTreeNode t = super.getJTreeNode(modus);
-		t.add(new DefaultMutableTreeNode(new KVP("network_name_encoding",networkName.getEncodingString() ,null)));
-		t.add(new DefaultMutableTreeNode(new KVP("network_name_length",networkName.getLength() ,null)));
-		t.add(new DefaultMutableTreeNode(new KVP("network_name",networkName ,null)));
+		t.add(new KVP("network_name",networkName));
 		return t;
 	}
 

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/ServiceDescriptor.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/ServiceDescriptor.java
@@ -43,9 +43,8 @@ public class ServiceDescriptor extends Descriptor{
 	public ServiceDescriptor(final byte[] b, final int offset, final TableSection parent) {
 		super(b, offset,parent);
 		serviceType = getInt(b, offset+2, 1, 0xFF);
-		final int serviceProviderNameLength = getInt(b, offset+3, 1, 0xFF);
 		serviceProviderName = new DVBString(b,offset+3);
-		serviceName = new DVBString(b,offset+4+serviceProviderNameLength);
+		serviceName = new DVBString(b,offset+4+serviceProviderName.getLength());
 	}
 
 	public DVBString getServiceProviderName() {

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/ServiceDescriptor.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/ServiceDescriptor.java
@@ -40,11 +40,11 @@ public class ServiceDescriptor extends Descriptor{
 	private final DVBString  serviceProviderName;
 	private final DVBString  serviceName;
 
-	public ServiceDescriptor(final byte[] b, final int offset, final TableSection parent) {
-		super(b, offset,parent);
-		serviceType = getInt(b, offset+2, 1, 0xFF);
-		serviceProviderName = new DVBString(b,offset+3);
-		serviceName = new DVBString(b,offset+4+serviceProviderName.getLength());
+	public ServiceDescriptor(final byte[] b, final TableSection parent) {
+		super(b, parent);
+		serviceType = getInt(b, 2, 1, 0xFF);
+		serviceProviderName = new DVBString(b, 3);
+		serviceName = new DVBString(b, 4 + serviceProviderName.getLength());
 	}
 
 	public DVBString getServiceProviderName() {
@@ -54,19 +54,15 @@ public class ServiceDescriptor extends Descriptor{
 
 	@Override
 	public String toString() {
-		return super.toString() + " service_type"+serviceType + "("+ getServiceTypeString(serviceType)+"), serviceProviderName="+getServiceProviderName()+ "serviceName="+getServiceName();
+		return super.toString() + " service_type"+serviceType + "("+ getServiceTypeString(serviceType)+"), serviceProviderName="+serviceProviderName+ "serviceName="+serviceName;
 	}
 
 	@Override
 	public DefaultMutableTreeNode getJTreeNode(final int modus){
 		final DefaultMutableTreeNode t = super.getJTreeNode(modus);
-		t.add(new DefaultMutableTreeNode(new KVP("service_type",serviceType ,getServiceTypeString(serviceType))));
-		t.add(new DefaultMutableTreeNode(new KVP("service_provider_name_encoding",serviceProviderName.getEncodingString() ,null)));
-		t.add(new DefaultMutableTreeNode(new KVP("service_provider_name_length",serviceProviderName.getLength() ,null)));
-		t.add(new DefaultMutableTreeNode(new KVP("service_provider_name",serviceProviderName ,null)));
-		t.add(new DefaultMutableTreeNode(new KVP("service_name_encoding",serviceName.getEncodingString() ,null)));
-		t.add(new DefaultMutableTreeNode(new KVP("service_name_length",serviceName.getLength() ,null)));
-		t.add(new DefaultMutableTreeNode(new KVP("service_name",serviceName ,null)));
+		t.add(new KVP("service_type",serviceType).setDescription(getServiceTypeString(serviceType)));
+		t.add(new KVP("service_provider_name",serviceProviderName));
+		t.add(new KVP("service_name",serviceName));
 		return t;
 	}
 
@@ -76,15 +72,6 @@ public class ServiceDescriptor extends Descriptor{
 
 	public int getServiceType() {
 		return serviceType;
-	}
-
-	public int getServiceNameLength() {
-		return serviceName.getLength();
-	}
-
-
-	public int getServiceProviderNameLength() {
-		return serviceProviderName.getLength();
 	}
 
 }

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/ServiceIdentifierDescriptor.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/ServiceIdentifierDescriptor.java
@@ -44,9 +44,9 @@ public class ServiceIdentifierDescriptor extends Descriptor {
 
 	private final DVBString textual_service_identifier_bytes;
 
-	public ServiceIdentifierDescriptor(final byte[] b, final int offset, final TableSection parent) {
-		super(b, offset,parent);
-		textual_service_identifier_bytes = new DVBString(b,offset+1);
+	public ServiceIdentifierDescriptor(final byte[] b, final TableSection parent) {
+		super(b, parent);
+		textual_service_identifier_bytes = new DVBString(b, 1);
 	}
 
 	public String getNetworkNameAsString()
@@ -62,9 +62,7 @@ public class ServiceIdentifierDescriptor extends Descriptor {
 	@Override
 	public DefaultMutableTreeNode getJTreeNode(final int modus){
 		final DefaultMutableTreeNode t = super.getJTreeNode(modus);
-		t.add(new DefaultMutableTreeNode(new KVP("textual_service_identifier_bytes_encoding",textual_service_identifier_bytes.getEncodingString() ,null)));
-		t.add(new DefaultMutableTreeNode(new KVP("textual_service_identifier_bytes_length",textual_service_identifier_bytes.getLength() ,null)));
-		t.add(new DefaultMutableTreeNode(new KVP("textual_service_identifier_bytes",textual_service_identifier_bytes ,null)));
+		t.add(new KVP("textual_service_identifier_bytes",textual_service_identifier_bytes));
 		return t;
 	}
 

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/ShortEventDescriptor.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/ShortEventDescriptor.java
@@ -74,11 +74,7 @@ public class ShortEventDescriptor extends LanguageDependentEitDescriptor{
 			}
 		} else {
 			t.add(new KVP("ISO_639_language_code", iso639LanguageCode));
-			t.add(new KVP("event_name_encoding", eventName.getEncodingString()));
-			t.add(new KVP("event_name_length", eventName.getLength()));
 			t.add(new KVP("event_name", eventName));
-			t.add(new KVP("text_encoding", text.getEncodingString()));
-			t.add(new KVP("text_length", text.getLength()));
 			t.add(new KVP("text", text));
 		}
 		return t;

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/ShortEventDescriptor.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/ShortEventDescriptor.java
@@ -2,7 +2,7 @@
  * 
  *  http://www.digitalekabeltelevisie.nl/dvb_inspector
  * 
- *  This code is Copyright 2009-2020 by Eric Berendsen (e_berendsen@digitalekabeltelevisie.nl)
+ *  This code is Copyright 2009-2024 by Eric Berendsen (e_berendsen@digitalekabeltelevisie.nl)
  * 
  *  This file is part of DVB Inspector.
  * 
@@ -27,9 +27,9 @@
 
 package nl.digitalekabeltelevisie.data.mpeg.descriptors;
 
-import static nl.digitalekabeltelevisie.util.Utils.*;
-
-import javax.swing.tree.DefaultMutableTreeNode;
+import static nl.digitalekabeltelevisie.util.Utils.MASK_8BITS;
+import static nl.digitalekabeltelevisie.util.Utils.getISO8859_1String;
+import static nl.digitalekabeltelevisie.util.Utils.getInt;
 
 import nl.digitalekabeltelevisie.controller.DVBString;
 import nl.digitalekabeltelevisie.controller.KVP;
@@ -43,21 +43,17 @@ public class ShortEventDescriptor extends LanguageDependentEitDescriptor{
 	private final DVBString eventName;
 	private DVBString text;
 
-	public ShortEventDescriptor(final byte[] b, final int offset, final TableSection parent) {
-		super(b, offset,parent);
-		iso639LanguageCode = getISO8859_1String(b,offset+2,3);
-		final int eventNameLength = getInt(b, offset+5, 1, MASK_8BITS);
-		eventName = new DVBString(b,offset+5);
-		text = new DVBString(b,offset+6 +eventNameLength);
-
+	public ShortEventDescriptor(final byte[] b, final TableSection parent) {
+		super(b, parent);
+		iso639LanguageCode = getISO8859_1String(b, 2, 3);
+		final int eventNameLength = getInt(b, 5, 1, MASK_8BITS);
+		eventName = new DVBString(b, 5);
+		text = new DVBString(b, 6 + eventNameLength);
 	}
 
+	@Override
 	public String getIso639LanguageCode() {
 		return iso639LanguageCode;
-	}
-
-	public void setIso639LanguageCode(final String networkName) {
-		this.iso639LanguageCode = networkName;
 	}
 
 	@Override
@@ -66,25 +62,24 @@ public class ShortEventDescriptor extends LanguageDependentEitDescriptor{
 	}
 
 	@Override
-	public DefaultMutableTreeNode getJTreeNode(final int modus){
-		final DefaultMutableTreeNode t = super.getJTreeNode(modus);
-		if(Utils.simpleModus(modus)){
-			t.add(new DefaultMutableTreeNode(new KVP("ISO_639_language_code",iso639LanguageCode ,null)));
-			if(eventName.getLength()>0){
-				t.add(new DefaultMutableTreeNode(new KVP("event_name",eventName ,null)));
+	public KVP getJTreeNode(final int modus) {
+		final KVP t = super.getJTreeNode(modus);
+		if (Utils.simpleModus(modus)) {
+			t.add(new KVP("ISO_639_language_code", iso639LanguageCode));
+			if (eventName.getLength() > 0) {
+				t.add(new KVP("event_name", eventName));
 			}
-			if(text.getLength()>0){
-				t.add(new DefaultMutableTreeNode(new KVP("text",text,null)));
+			if (text.getLength() > 0) {
+				t.add(new KVP("text", text));
 			}
-		}else{
-			t.add(new DefaultMutableTreeNode(new KVP("ISO_639_language_code",iso639LanguageCode ,null)));
-			t.add(new DefaultMutableTreeNode(new KVP("event_name_encoding",eventName.getEncodingString(),null)));
-			t.add(new DefaultMutableTreeNode(new KVP("event_name_length",eventName.getLength(),null)));
-			t.add(new DefaultMutableTreeNode(new KVP("event_name",eventName ,null)));
-			t.add(new DefaultMutableTreeNode(new KVP("text_encoding",text.getEncodingString(),null)));
-			t.add(new DefaultMutableTreeNode(new KVP("text_length",text.getLength(),null)));
-			t.add(new DefaultMutableTreeNode(new KVP("text",text,null)));
-
+		} else {
+			t.add(new KVP("ISO_639_language_code", iso639LanguageCode));
+			t.add(new KVP("event_name_encoding", eventName.getEncodingString()));
+			t.add(new KVP("event_name_length", eventName.getLength()));
+			t.add(new KVP("event_name", eventName));
+			t.add(new KVP("text_encoding", text.getEncodingString()));
+			t.add(new KVP("text_length", text.getLength()));
+			t.add(new KVP("text", text));
 		}
 		return t;
 	}
@@ -95,10 +90,6 @@ public class ShortEventDescriptor extends LanguageDependentEitDescriptor{
 
 	public DVBString getText() {
 		return text;
-	}
-
-	public void setText(final DVBString text) {
-		this.text = text;
 	}
 
 }

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/aitable/AITDescriptor.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/aitable/AITDescriptor.java
@@ -37,15 +37,14 @@ import nl.digitalekabeltelevisie.data.mpeg.psi.TableSection;
 public class AITDescriptor extends Descriptor {
 
 
-	/**
-	 * @param b
-	 * @param offset
-	 * @param parent
-	 */
-	public AITDescriptor(final byte[] b, final int offset, final TableSection parent) {
-		super(b, offset, parent);
+	public AITDescriptor(byte[] b, int offset, TableSection parent) {
+		super(b, parent);
 	}
 
+
+	public AITDescriptor(byte[] b, TableSection parent) {
+		super(b, parent);
+	}
 	@Override
 	public String getDescriptorname(){
 		return AITDescriptor.getDescriptorname(descriptorTag, parentTableSection);

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/aitable/ApplicationNameDescriptor.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/aitable/ApplicationNameDescriptor.java
@@ -44,82 +44,32 @@ import nl.digitalekabeltelevisie.data.mpeg.psi.TableSection;
  *
  */
 public class ApplicationNameDescriptor extends AITDescriptor {
-	private List<ApplicationName> applicationNames= new ArrayList<ApplicationName>();
+	private List<ApplicationName> applicationNames= new ArrayList<>();
 
 
 	public List<ApplicationName> getApplicationNames() {
 		return applicationNames;
 	}
 
-	public static class ApplicationName implements TreeNode{
-		/**
-		 *
-		 */
-		private String iso639LanguageCode;
-		/**
-		 *
-		 */
-		private final int application_name_length;
-		private final DVBString application_name;
-
-
-		public ApplicationName(final String lCode, final int application_name_length, final DVBString application_name){
-			iso639LanguageCode = lCode;
-			this.application_name_length = application_name_length;
-			this.application_name = application_name;
-		}
-
-
-		public DefaultMutableTreeNode getJTreeNode(final int modus){
-			final DefaultMutableTreeNode s=new DefaultMutableTreeNode(new KVP("application_name: "+application_name));
-			s.add(new DefaultMutableTreeNode(new KVP("ISO_639_language_code",iso639LanguageCode,null)));
-			s.add(new DefaultMutableTreeNode(new KVP("application_name_length",application_name_length,null)));
-			s.add(new DefaultMutableTreeNode(new KVP("application_name_encoding",application_name.getEncodingString(),null)));
-			s.add(new DefaultMutableTreeNode(new KVP("application_name",application_name,null)));
+	public static record ApplicationName(String iso639LanguageCode, DVBString application_name) implements TreeNode{
+		@Override
+		public KVP getJTreeNode(final int modus) {
+			final KVP s = new KVP("application_name: " + application_name);
+			s.add(new KVP("ISO_639_language_code", iso639LanguageCode));
+			s.add(new KVP("application_name", application_name));
 			return s;
 		}
-
-
-
-		public String getIso639LanguageCode() {
-			return iso639LanguageCode;
-		}
-
-
-		public void setIso639LanguageCode(final String iso639LanguageCode) {
-			this.iso639LanguageCode = iso639LanguageCode;
-		}
-
-		@Override
-		public String toString(){
-			return "code:'"+iso639LanguageCode+"', application_name:"+application_name;
-		}
-
-
-		public int getApplication_name_length() {
-			return application_name_length;
-		}
-
-
-		public DVBString getApplication_name() {
-			return application_name;
-		}
-
-
 	}
 
-	public ApplicationNameDescriptor(final byte[] b, final int offset, final TableSection parent) {
-		super(b, offset,parent);
-		int t=0;
-		while (t<descriptorLength) {
-			final String languageCode=getISO8859_1String(b, offset+t+2, 3);
-
-			final int application_name_length = getInt(b, offset+t+5, 1, MASK_8BITS);
-			final DVBString application_name =new DVBString(b, offset+t+5);
-
-			final ApplicationName s = new ApplicationName(languageCode, application_name_length,application_name);
-			applicationNames.add(s);
-			t+=4+application_name_length;
+	public ApplicationNameDescriptor(byte[] b, TableSection parent) {
+		super(b, parent);
+		int t = 0;
+		while (t < descriptorLength) {
+			final String languageCode = getISO8859_1String(b, t + 2, 3);
+			final DVBString application_name = new DVBString(b, t + 5);
+			final ApplicationName applicationName = new ApplicationName(languageCode, application_name);
+			applicationNames.add(applicationName);
+			t += 4 + application_name.getLength();
 		}
 	}
 

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/dsmcc/DSMCCDescriptor.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/dsmcc/DSMCCDescriptor.java
@@ -41,7 +41,7 @@ public class DSMCCDescriptor extends Descriptor {
 	 * @param parent
 	 */
 	public DSMCCDescriptor(final byte[] b, final int offset) {
-		super(b, offset, null);
+		super(b, null);
 	}
 
 	@Override

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/dsmcc/DSMCCDescriptorFactory.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/dsmcc/DSMCCDescriptorFactory.java
@@ -30,6 +30,7 @@ package nl.digitalekabeltelevisie.data.mpeg.descriptors.dsmcc;
 import static java.lang.Byte.toUnsignedInt;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Logger;
 
@@ -49,14 +50,17 @@ public final class DSMCCDescriptorFactory {
 
 
 	public static List<Descriptor> buildDescriptorList(final byte[] data, final int offset, final int len) {
-		final List<Descriptor> r = new ArrayList<Descriptor>();
+		final List<Descriptor> r = new ArrayList<>();
 		int t = 0;
 
 		while (t < len) {
 
+			int descriptorLen = toUnsignedInt(data[offset + t+ 1]);
+			byte[] descriptorData = Arrays.copyOfRange(data, offset + t, offset + t + descriptorLen + 2);
+
 			Descriptor d;
 			try {
-				d = getDSMCCDescriptor(data, offset,t);
+				d = getDSMCCDescriptor(descriptorData);
 
 			} catch (final RuntimeException iae) {
 				// this can happen because there is an error in our code (constructor of a descriptor), OR the stream is invalid.
@@ -74,40 +78,40 @@ public final class DSMCCDescriptorFactory {
 		return r;
 	}
 
-	private static Descriptor getDSMCCDescriptor(final byte[] data, final int offset, final int t) {
+	private static Descriptor getDSMCCDescriptor(byte[] data) {
 		Descriptor d;
-		switch (toUnsignedInt(data[t + offset])) {
+		switch (toUnsignedInt(data[0])) {
 		case 0x02:
-			d = new NameDescriptor(data, t + offset);
+			d = new NameDescriptor(data);
 			break;
 		case 0x04:
-			d = new ModuleLinkDescriptor(data, t + offset);
+			d = new ModuleLinkDescriptor(data, 0);
 			break;
 		case 0x05:
-			d = new CRC32Descriptor(data, t + offset);
+			d = new CRC32Descriptor(data,0);
 			break;
 
 		case 0x09:
-			d = new CompressedModuleDescriptor(data, t + offset);
+			d = new CompressedModuleDescriptor(data, 0);
 			break;
 
 
 		case 0x0A:
-			d = new SSUModuleTypeDescriptor(data, t + offset);
+			d = new SSUModuleTypeDescriptor(data, 0);
 			break;
 
 		case 0x70:
-			d = new LabelDescriptor(data, t + offset);
+			d = new LabelDescriptor(data, 0);
 			break;
 
 		case 0x71:
-			d = new CachingPriorityDescriptor(data, t + offset);
+			d = new CachingPriorityDescriptor(data, 0);
 			break;
 
 		default:
-			d = new DSMCCDescriptor(data, t + offset);
-			logger.info("Not implemented DSMCCDescriptor:" + toUnsignedInt(data[t + offset]) + " ("
-					+ DSMCCDescriptor.getDescriptorname(toUnsignedInt(data[t + offset]))
+			d = new DSMCCDescriptor(data, 0);
+			logger.info("Not implemented DSMCCDescriptor:" + toUnsignedInt(data[0]) + " ("
+					+ DSMCCDescriptor.getDescriptorname(toUnsignedInt(data[0]))
 					+ ",) data=" + d.getRawDataString());
 			break;
 		}

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/dsmcc/DSMCCStreamEventPayloadBinary.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/dsmcc/DSMCCStreamEventPayloadBinary.java
@@ -27,23 +27,17 @@
 
 package nl.digitalekabeltelevisie.data.mpeg.descriptors.dsmcc;
 
-import static nl.digitalekabeltelevisie.util.Utils.MASK_16BITS;
-import static nl.digitalekabeltelevisie.util.Utils.getInt;
+import static nl.digitalekabeltelevisie.util.Utils.*;
 
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Base64.Decoder;
 
-import javax.swing.tree.DefaultMutableTreeNode;
-
 import nl.digitalekabeltelevisie.controller.DVBString;
 import nl.digitalekabeltelevisie.controller.KVP;
 import nl.digitalekabeltelevisie.controller.TreeNode;
 import nl.digitalekabeltelevisie.data.mpeg.PsiSectionData;
-import nl.digitalekabeltelevisie.data.mpeg.psi.SCTE35;
 import nl.digitalekabeltelevisie.data.mpeg.psi.SpliceInfoSection;
-
-import static nl.digitalekabeltelevisie.util.Utils.*;
 
 
 /**
@@ -62,7 +56,6 @@ public class DSMCCStreamEventPayloadBinary implements TreeNode {
 	private int private_data_length;
 	private long private_data_specifier;
 	private byte[] private_data_byte;
-	private int carousel_object_name_length;
 	private DVBString carousel_object_name;
 	
 	SpliceInfoSection scte35_section;
@@ -98,9 +91,8 @@ public class DSMCCStreamEventPayloadBinary implements TreeNode {
 			}
 			
 			if (event_type == 1) {
-				carousel_object_name_length  = getInt(binary, offset++, 1, MASK_8BITS);
-				carousel_object_name = new DVBString(binary, offset, carousel_object_name_length);
-				offset += carousel_object_name_length;
+				carousel_object_name = new DVBString(binary, offset);
+				offset += 1 + carousel_object_name.getLength();
 				
 			}
 	
@@ -115,31 +107,30 @@ public class DSMCCStreamEventPayloadBinary implements TreeNode {
 	}
 
 	@Override
-	public DefaultMutableTreeNode getJTreeNode(int modus) {
-		final DefaultMutableTreeNode t = new DefaultMutableTreeNode(new KVP("DSM-CC_stream_event_payload_binary"));
-		t.add(new DefaultMutableTreeNode(new KVP("binary", binary, null)));
+	public KVP getJTreeNode(int modus) {
+		final KVP t = new KVP("DSM-CC_stream_event_payload_binary");
+		t.add(new KVP("binary", binary));
 		if (binary.length > 0) {
-			t.add(new DefaultMutableTreeNode(new KVP("DVB_data_length", dvb_data_length, null)));
-			t.add(new DefaultMutableTreeNode(new KVP("reserved_zero_future_use", reserved_zero_future_use, null)));
-			t.add(new DefaultMutableTreeNode(new KVP("event_type", event_type, null)));
-			t.add(new DefaultMutableTreeNode(new KVP("timeline_type", timeline_type, null)));
+			t.add(new KVP("DVB_data_length", dvb_data_length));
+			t.add(new KVP("reserved_zero_future_use", reserved_zero_future_use));
+			t.add(new KVP("event_type", event_type));
+			t.add(new KVP("timeline_type", timeline_type));
 
 			if (timeline_type == 0x2) {
-				t.add(new DefaultMutableTreeNode(new KVP("temi_component_tag", temi_component_tag, null)));
-				t.add(new DefaultMutableTreeNode(new KVP("temi_timeline_id", temi_timeline_id, null)));
+				t.add(new KVP("temi_component_tag", temi_component_tag));
+				t.add(new KVP("temi_timeline_id", temi_timeline_id));
 			}
 			if(reserved_zero_future_use2 != null) {
-				t.add(new DefaultMutableTreeNode(new KVP("reserved_zero_future_use", reserved_zero_future_use2, null)));
+				t.add(new KVP("reserved_zero_future_use", reserved_zero_future_use2));
 			}
-			t.add(new DefaultMutableTreeNode(new KVP("private_data_length", private_data_length, null)));
+			t.add(new KVP("private_data_length", private_data_length));
 			
 			if (private_data_length > 0) {
-				t.add(new DefaultMutableTreeNode(new KVP("private_data_specifier", private_data_specifier, getPrivateDataSpecString(private_data_specifier))));
-				t.add(new DefaultMutableTreeNode(new KVP("private_data_byte", private_data_byte, null)));
+				t.add(new KVP("private_data_specifier", private_data_specifier).setDescription(getPrivateDataSpecString(private_data_specifier)));
+				t.add(new KVP("private_data_byte", private_data_byte));
 			}
 			if (event_type == 1) {
-				t.add(new DefaultMutableTreeNode(new KVP("carousel_object_name_length", carousel_object_name_length, null)));
-				t.add(new DefaultMutableTreeNode(new KVP("carousel_object_name", carousel_object_name, null)));
+				t.add(new KVP("carousel_object_name", carousel_object_name));
 			}
 			if (event_type == 0) {
 				t.add(scte35_section.getJTreeNode(2));

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/dsmcc/NameDescriptor.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/dsmcc/NameDescriptor.java
@@ -37,15 +37,15 @@ public class NameDescriptor extends DSMCCDescriptor {
 
 	private final DVBString text_char;
 
-	public NameDescriptor(byte[] b, int offset) {
-		super(b, offset);
-		text_char = new DVBString(b,offset+1);
+	public NameDescriptor(byte[] b) {
+		super(b, 0);
+		text_char = new DVBString(b, 1);
 	}
 
 	@Override
 	public DefaultMutableTreeNode getJTreeNode(final int modus){
 		final DefaultMutableTreeNode t = super.getJTreeNode(modus);
-		t.add(new DefaultMutableTreeNode(new KVP("text_char",text_char ,null)));
+		t.add(new KVP("text_char",text_char));
 		return t;
 	}
 

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/extension/dvb/CIAncillaryDataDescriptor.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/extension/dvb/CIAncillaryDataDescriptor.java
@@ -2,7 +2,7 @@
  *
  *  http://www.digitalekabeltelevisie.nl/dvb_inspector
  *
- *  This code is Copyright 2009-2017 by Eric Berendsen (e_berendsen@digitalekabeltelevisie.nl)
+ *  This code is Copyright 2009-2024 by Eric Berendsen (e_berendsen@digitalekabeltelevisie.nl)
  *
  *  This file is part of DVB Inspector.
  *
@@ -27,7 +27,7 @@
 
 package nl.digitalekabeltelevisie.data.mpeg.descriptors.extension.dvb;
 
-import static nl.digitalekabeltelevisie.util.Utils.*;
+import static java.util.Arrays.copyOfRange;
 
 import javax.swing.tree.DefaultMutableTreeNode;
 
@@ -38,16 +38,16 @@ public class CIAncillaryDataDescriptor extends DVBExtensionDescriptor {
 
 	private final byte[] ancillary_data_byte;
 
-	public CIAncillaryDataDescriptor(final byte[] b, final int offset, final TableSection parent) {
-		super(b, offset, parent);
-		ancillary_data_byte = copyOfRange(b, privateDataOffset, privateDataOffset + descriptorLength - 1);
+	public CIAncillaryDataDescriptor(final byte[] b, final TableSection parent) {
+		super(b, parent);
+		ancillary_data_byte = copyOfRange(b, PRIVATE_DATA_OFFSET, PRIVATE_DATA_OFFSET + descriptorLength - 1);
 	}
 
 	@Override
 	public DefaultMutableTreeNode getJTreeNode(final int modus) {
 
 		final DefaultMutableTreeNode t = super.getJTreeNode(modus);
-		t.add(new DefaultMutableTreeNode(new KVP("ancillary_data_byte", ancillary_data_byte, null)));
+		t.add(new KVP("ancillary_data_byte", ancillary_data_byte));
 		return t;
 	}
 

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/extension/dvb/DVBExtensionDescriptor.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/extension/dvb/DVBExtensionDescriptor.java
@@ -32,8 +32,12 @@ import nl.digitalekabeltelevisie.data.mpeg.psi.TableSection;
 
 public class DVBExtensionDescriptor extends ExtensionDescriptor {
 
-	public DVBExtensionDescriptor(final byte[] b, final int offset, final TableSection parent) {
-		super(b, offset, parent);
+	public DVBExtensionDescriptor(byte[] b, int offset, TableSection parent) {
+		super(b, parent);
+	}
+
+	public DVBExtensionDescriptor(byte[] b, TableSection parent) {
+		super(b, parent);
 	}
 
 	public static String getDescriptorTagString(final int descriptor_tag_extension) {

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/extension/dvb/ServiceRelocatedDescriptor.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/extension/dvb/ServiceRelocatedDescriptor.java
@@ -45,11 +45,12 @@ public class ServiceRelocatedDescriptor extends DVBExtensionDescriptor {
 
 	public ServiceRelocatedDescriptor(final byte[] b, final int offset, final TableSection parent) {
 		super(b, offset,parent);
-		old_original_network_id = getInt(b, privateDataOffset, 2, MASK_16BITS);
-		privateDataOffset += 2;
-		old_transport_stream_id = getInt(b, privateDataOffset, 2, MASK_16BITS);
-		privateDataOffset += 2;
-		old_service_id = getInt(b, privateDataOffset, 2, MASK_16BITS);
+		int localOffset = PRIVATE_DATA_OFFSET;
+		old_original_network_id = getInt(b, localOffset, 2, MASK_16BITS);
+		localOffset += 2;
+		old_transport_stream_id = getInt(b, localOffset, 2, MASK_16BITS);
+		localOffset += 2;
+		old_service_id = getInt(b, localOffset, 2, MASK_16BITS);
 	}
 
 
@@ -57,9 +58,9 @@ public class ServiceRelocatedDescriptor extends DVBExtensionDescriptor {
 	public DefaultMutableTreeNode getJTreeNode(final int modus){
 
 		final DefaultMutableTreeNode t = super.getJTreeNode(modus);
-		t.add(new DefaultMutableTreeNode(new KVP("old_original_network_id",old_original_network_id,null)));
-		t.add(new DefaultMutableTreeNode(new KVP("old_transport_stream_id",old_transport_stream_id,null)));
-		t.add(new DefaultMutableTreeNode(new KVP("old_service_id",old_service_id,null)));
+		t.add(new KVP("old_original_network_id", old_original_network_id));
+		t.add(new KVP("old_transport_stream_id", old_transport_stream_id));
+		t.add(new KVP("old_service_id", old_service_id));
 
 		return t;
 	}

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/extension/dvb/TtmlSubtitlingDescriptor.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/extension/dvb/TtmlSubtitlingDescriptor.java
@@ -53,9 +53,8 @@ public class TtmlSubtitlingDescriptor extends DVBExtensionDescriptor {
 		final int font_id;
 
 		@Override
-		public DefaultMutableTreeNode getJTreeNode(int modus) {
-			
-			return new DefaultMutableTreeNode(new KVP("font_id",font_id,null));
+		public KVP getJTreeNode(int modus) {
+			return new KVP("font_id",font_id);
 		}
 
 	}
@@ -108,14 +107,14 @@ public class TtmlSubtitlingDescriptor extends DVBExtensionDescriptor {
 		private final int reserved_zero_future_use;
 
 		@Override
-		public DefaultMutableTreeNode getJTreeNode(int modus) {
-			final DefaultMutableTreeNode t = new DefaultMutableTreeNode(new KVP("qualifier",qualifier,null));
-			t.add(new DefaultMutableTreeNode(new KVP("size", size, size_lookup_list.get(size))));
-			t.add(new DefaultMutableTreeNode(new KVP("cadence", cadence, cadence_lookup_list.get(cadence))));
-			t.add(new DefaultMutableTreeNode(new KVP("monochrome_flag", monochrome_flag, null)));
-			t.add(new DefaultMutableTreeNode(new KVP("enhanced_accessibility_contrast_flag", enhanced_accessibility_contrast_flag, null)));
-			t.add(new DefaultMutableTreeNode(new KVP("position", position, position_lookup_list.get(position))));
-			t.add(new DefaultMutableTreeNode(new KVP("reserved_zero_future_use", reserved_zero_future_use, null)));
+		public KVP getJTreeNode(int modus) {
+			final KVP t = new KVP("qualifier",qualifier);
+			t.add(new KVP("size", size).setDescription(size_lookup_list.get(size)));
+			t.add(new KVP("cadence", cadence).setDescription(cadence_lookup_list.get(cadence)));
+			t.add(new KVP("monochrome_flag", monochrome_flag));
+			t.add(new KVP("enhanced_accessibility_contrast_flag", enhanced_accessibility_contrast_flag));
+			t.add(new KVP("position", position).setDescription(position_lookup_list.get(position)));
+			t.add(new KVP("reserved_zero_future_use", reserved_zero_future_use));
 			return t;
 		}
 		
@@ -139,10 +138,8 @@ public class TtmlSubtitlingDescriptor extends DVBExtensionDescriptor {
 		private final int dvb_ttml_profile;
 
 		@Override
-		public DefaultMutableTreeNode getJTreeNode(int modus) {
-			
-			
-			return new DefaultMutableTreeNode(new KVP("dvb_ttml_profile",dvb_ttml_profile,dvb_ttml_profile_lookup_list.get(dvb_ttml_profile)));
+		public KVP getJTreeNode(int modus) {
+			return new KVP("dvb_ttml_profile",dvb_ttml_profile).setDescription(dvb_ttml_profile_lookup_list.get(dvb_ttml_profile));
 		}
 	
 	}
@@ -186,34 +183,35 @@ public class TtmlSubtitlingDescriptor extends DVBExtensionDescriptor {
 			add(0x3 ,"reserved for future use").
 			build(); 
 
-	public TtmlSubtitlingDescriptor(final byte[] b, final int offset, final TableSection parent) {
-		super(b, offset, parent);
-		iso639LanguageCode = Utils.getISO8859_1String(b, privateDataOffset, 3);
-		privateDataOffset +=3;
-		subtitle_purpose = getInt(b, privateDataOffset, 1, 0b1111_1100)>>2;
-		tts_suitability = getInt(b, privateDataOffset++, 1, MASK_2BITS);
-		essential_font_usage_flag  = getInt(b, privateDataOffset, 1, 0b1000_0000)>>7;
-		qualifier_present_flag  = getInt(b, privateDataOffset, 1, 0b0100_0000)>>6;
-		reserved_zero_future_use = getInt(b, privateDataOffset, 1, 0b0011_0000)>>4;
-		dvb_ttml_profile_count = getInt(b, privateDataOffset++, 1, MASK_4BITS);
+	public TtmlSubtitlingDescriptor(final byte[] b, final TableSection parent) {
+		super(b, parent);
+		int localOffset = PRIVATE_DATA_OFFSET;
+		iso639LanguageCode = Utils.getISO8859_1String(b, localOffset, 3);
+		localOffset +=3;
+		subtitle_purpose = getInt(b, localOffset, 1, 0b1111_1100)>>2;
+		tts_suitability = getInt(b, localOffset++, 1, MASK_2BITS);
+		essential_font_usage_flag  = getInt(b, localOffset, 1, 0b1000_0000)>>7;
+		qualifier_present_flag  = getInt(b, localOffset, 1, 0b0100_0000)>>6;
+		reserved_zero_future_use = getInt(b, localOffset, 1, 0b0011_0000)>>4;
+		dvb_ttml_profile_count = getInt(b, localOffset++, 1, MASK_4BITS);
 		for (int i = 0; i < dvb_ttml_profile_count; i++) {
-			DvbTtmlProfile profile = new DvbTtmlProfile(getInt(b, privateDataOffset++, 1, MASK_8BITS));
+			DvbTtmlProfile profile = new DvbTtmlProfile(getInt(b, localOffset++, 1, MASK_8BITS));
 			profileList.add(profile);
 		}
 		if(qualifier_present_flag == 1) {
-			qualifier = getLong(b, privateDataOffset, 4, MASK_32BITS);
-			privateDataOffset += 4;
+			qualifier = getLong(b, localOffset, 4, MASK_32BITS);
+			localOffset += 4;
 		}
 		if (essential_font_usage_flag == 1){
-			 font_count = getInt(b, privateDataOffset++, 1, MASK_8BITS);
+			 font_count = getInt(b, localOffset++, 1, MASK_8BITS);
 			 for(int i=0; i<font_count; i++){
-				 int f  = getInt(b, privateDataOffset++, 1, MASK_8BITS);
+				 int f  = getInt(b, localOffset++, 1, MASK_8BITS);
 				 Font font = new Font(f);
 				 fontList.add(font);
 			 }
 		}
 		
-		text = new DVBString(b, privateDataOffset);
+		text = new DVBString(b, localOffset);
 		
 	}
 
@@ -221,13 +219,13 @@ public class TtmlSubtitlingDescriptor extends DVBExtensionDescriptor {
 	public DefaultMutableTreeNode getJTreeNode(final int modus) {
 
 		final DefaultMutableTreeNode t = super.getJTreeNode(modus);
-		t.add(new DefaultMutableTreeNode(new KVP("iso639LanguageCode", iso639LanguageCode, null)));
-		t.add(new DefaultMutableTreeNode(new KVP("subtitle_purpose", subtitle_purpose, subtitle_purpose_list.get(subtitle_purpose))));
-		t.add(new DefaultMutableTreeNode(new KVP("TTS_suitability", tts_suitability, tts_suitability_list.get(tts_suitability))));
-		t.add(new DefaultMutableTreeNode(new KVP("essential_font_usage_flag", essential_font_usage_flag,null)));
-		t.add(new DefaultMutableTreeNode(new KVP("qualifier_present_flag", qualifier_present_flag,null)));
-		t.add(new DefaultMutableTreeNode(new KVP("reserved_zero_future_use", reserved_zero_future_use,null)));
-		t.add(new DefaultMutableTreeNode(new KVP("dvb_ttml_profile_count", dvb_ttml_profile_count,null)));
+		t.add(new KVP("iso639LanguageCode", iso639LanguageCode));
+		t.add(new KVP("subtitle_purpose", subtitle_purpose).setDescription(subtitle_purpose_list.get(subtitle_purpose)));
+		t.add(new KVP("TTS_suitability", tts_suitability).setDescription(tts_suitability_list.get(tts_suitability)));
+		t.add(new KVP("essential_font_usage_flag", essential_font_usage_flag));
+		t.add(new KVP("qualifier_present_flag", qualifier_present_flag));
+		t.add(new KVP("reserved_zero_future_use", reserved_zero_future_use));
+		t.add(new KVP("dvb_ttml_profile_count", dvb_ttml_profile_count));
 		addListJTree(t,profileList,modus,"dvb_ttml_profile_list");
 		
 		if(qualifier_present_flag == 1) {
@@ -235,13 +233,13 @@ public class TtmlSubtitlingDescriptor extends DVBExtensionDescriptor {
 		}
 		
 		if (essential_font_usage_flag == 1){
-			t.add(new DefaultMutableTreeNode(new KVP("font_count", font_count,null)));
+			t.add(new KVP("font_count", font_count));
 			addListJTree(t,fontList,modus,"font_list");
 		}
 
-		t.add(new DefaultMutableTreeNode(new KVP("text_encoding",text.getEncodingString(),null)));
-		t.add(new DefaultMutableTreeNode(new KVP("text_length",text.getLength(),null)));
-		t.add(new DefaultMutableTreeNode(new KVP("text",text,null)));
+		t.add(new KVP("text_encoding",text.getEncodingString()));
+		t.add(new KVP("text_length",text.getLength()));
+		t.add(new KVP("text",text));
 		
 		
 

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/extension/dvb/TtmlSubtitlingDescriptor.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/extension/dvb/TtmlSubtitlingDescriptor.java
@@ -237,8 +237,6 @@ public class TtmlSubtitlingDescriptor extends DVBExtensionDescriptor {
 			addListJTree(t,fontList,modus,"font_list");
 		}
 
-		t.add(new KVP("text_encoding",text.getEncodingString()));
-		t.add(new KVP("text_length",text.getLength()));
 		t.add(new KVP("text",text));
 		
 		

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/extension/dvb/URILinkageDescriptor.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/extension/dvb/URILinkageDescriptor.java
@@ -27,6 +27,7 @@
 
 package nl.digitalekabeltelevisie.data.mpeg.descriptors.extension.dvb;
 
+import static java.util.Arrays.copyOfRange;
 import static nl.digitalekabeltelevisie.util.Utils.*;
 
 import javax.swing.tree.DefaultMutableTreeNode;
@@ -53,18 +54,19 @@ public class URILinkageDescriptor extends DVBExtensionDescriptor {
 
 
 	public URILinkageDescriptor(final byte[] b, final int offset, final TableSection parent) {
-		super(b, offset,parent);
-		uri_linkage_type = getInt(b, privateDataOffset++, 1, MASK_8BITS);
-		uri_length = getInt(b, privateDataOffset++, 1, MASK_8BITS);
-		uri_char = copyOfRange(b, privateDataOffset,privateDataOffset + uri_length);
-		privateDataOffset += uri_length; 
+		super(b, parent);
+		int localOffset = PRIVATE_DATA_OFFSET;
+		uri_linkage_type = getInt(b, localOffset++, 1, MASK_8BITS);
+		uri_length = getInt(b, localOffset++, 1, MASK_8BITS);
+		uri_char = copyOfRange(b, localOffset, localOffset + uri_length);
+		localOffset += uri_length; 
 		
 		if ((uri_linkage_type == 0x00) || (uri_linkage_type == 0x01)) {
-				min_polling_interval = getInt(b, privateDataOffset, 2, MASK_16BITS);
-				privateDataOffset += 2;
+				min_polling_interval = getInt(b, localOffset, 2, MASK_16BITS);
+				localOffset += 2;
 		}
-		if ((offset + 2 + descriptorLength) < privateDataOffset) {
-			private_data_byte = copyOfRange(b, privateDataOffset, privateDataOffset + descriptorLength + 2);
+		if ((PRIVATE_DATA_OFFSET + descriptorLength) < localOffset) {
+			private_data_byte = copyOfRange(b, localOffset, localOffset + descriptorLength + 2);
 		}
 	}
 
@@ -72,15 +74,14 @@ public class URILinkageDescriptor extends DVBExtensionDescriptor {
 	public DefaultMutableTreeNode getJTreeNode(final int modus) {
 
 		final DefaultMutableTreeNode t = super.getJTreeNode(modus);
-		t.add(new DefaultMutableTreeNode(
-				new KVP("uri_linkage_type", uri_linkage_type, getURILinkageTypeString(uri_linkage_type))));
-		t.add(new DefaultMutableTreeNode(new KVP("uri_length", uri_length, null)));
-		t.add(new DefaultMutableTreeNode(new KVP("uri_char", uri_char, null)));
+		t.add(new KVP("uri_linkage_type", uri_linkage_type).setDescription(getURILinkageTypeString(uri_linkage_type)));
+		t.add(new KVP("uri_length", uri_length));
+		t.add(new KVP("uri_char", uri_char));
 		if ((uri_linkage_type == 0x00) || (uri_linkage_type == 0x01)) {
-			t.add(new DefaultMutableTreeNode(new KVP("min_polling_interval", min_polling_interval, null)));
+			t.add(new KVP("min_polling_interval", min_polling_interval));
 		}
 		if (private_data_byte != null) {
-			t.add(new DefaultMutableTreeNode(new KVP("private_data_byte", private_data_byte, null)));
+			t.add(new KVP("private_data_byte", private_data_byte));
 		}
 		return t;
 	}

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/extension/dvb/VvcSubpicturesDescriptor.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/extension/dvb/VvcSubpicturesDescriptor.java
@@ -64,9 +64,9 @@ public class VvcSubpicturesDescriptor extends DVBExtensionDescriptor {
 		@Override
 		public DefaultMutableTreeNode getJTreeNode(final int modus){
 
-			final DefaultMutableTreeNode t = new DefaultMutableTreeNode(new KVP("sub_picture"));
-			t.add(new DefaultMutableTreeNode(new KVP("component_tag",component_tag,null)));
-			t.add(new DefaultMutableTreeNode(new KVP("vvc_subpicture_id",vvc_subpicture_id,null)));
+			final KVP t = new KVP("sub_picture");
+			t.add(new KVP("component_tag",component_tag));
+			t.add(new KVP("vvc_subpicture_id",vvc_subpicture_id));
 
 			return t;
 		}
@@ -83,14 +83,14 @@ public class VvcSubpicturesDescriptor extends DVBExtensionDescriptor {
 	private int processing_mode;
 	private DVBString service_description;
 
-	public VvcSubpicturesDescriptor(byte[] b, int offset, TableSection parent) {
-		super(b, offset, parent);
+	public VvcSubpicturesDescriptor(byte[] b, TableSection parent) {
+		super(b, parent);
 		
-		default_service_mode = getInt(b, offset + 3, 1, 0b1000_0000) >> 7;
-		service_description_present = getInt(b, offset + 3, 1, 0b0100_0000) >> 6;
-		number_of_vvc_subpictures = getInt(b, offset + 3, 1, Utils.MASK_6BITS);
+		default_service_mode = getInt(b,  3, 1, 0b1000_0000) >> 7;
+		service_description_present = getInt(b, 3, 1, 0b0100_0000) >> 6;
+		number_of_vvc_subpictures = getInt(b,  3, 1, Utils.MASK_6BITS);
 		
-		int localOffset = offset+4;
+		int localOffset = 4;
 		
 		for (int i=0;i<number_of_vvc_subpictures;i++) {
 			int component_tag = getInt(b, localOffset++, 1, Utils.MASK_6BITS);
@@ -110,17 +110,17 @@ public class VvcSubpicturesDescriptor extends DVBExtensionDescriptor {
 	public DefaultMutableTreeNode getJTreeNode(final int modus){
 
 		final DefaultMutableTreeNode t = super.getJTreeNode(modus);
-		t.add(new DefaultMutableTreeNode(new KVP("default_service_mode",default_service_mode,null)));
-		t.add(new DefaultMutableTreeNode(new KVP("service_description_present",service_description_present,null)));
-		t.add(new DefaultMutableTreeNode(new KVP("number_of_vvc_subpictures",number_of_vvc_subpictures,null)));
+		t.add(new KVP("default_service_mode",default_service_mode));
+		t.add(new KVP("service_description_present",service_description_present));
+		t.add(new KVP("number_of_vvc_subpictures",number_of_vvc_subpictures));
 
 		Utils.addListJTree(t, subPicturesList, modus, "subpictures");
 
-		t.add(new DefaultMutableTreeNode(new KVP("reserved_zero_future_use",reserved_zero_future_use,null)));
-		t.add(new DefaultMutableTreeNode(new KVP("processing_mode",processing_mode,processing_mode_list.get(processing_mode))));
+		t.add(new KVP("reserved_zero_future_use",reserved_zero_future_use));
+		t.add(new KVP("processing_mode",processing_mode).setDescription(processing_mode_list.get(processing_mode)));
 
 		if(service_description_present == 0b1) {
-			t.add(new DefaultMutableTreeNode(new KVP("service_description",service_description,null)));
+			t.add(new KVP("service_description",service_description));
 		}
 
 		return t;

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/extension/mpeg/HEVCTimingAndHRDDescriptor.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/extension/mpeg/HEVCTimingAndHRDDescriptor.java
@@ -1,3 +1,30 @@
+/**
+ *
+ *  http://www.digitalekabeltelevisie.nl/dvb_inspector
+ *
+ *  This code is Copyright 2009-2024 by Eric Berendsen (e_berendsen@digitalekabeltelevisie.nl)
+ *
+ *  This file is part of DVB Inspector.
+ *
+ *  DVB Inspector is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  DVB Inspector is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with DVB Inspector.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  The author requests that he be notified of any application, applet, or
+ *  other binary that makes use of this code, but that's more out of curiosity
+ *  than anything and is not required.
+ *
+ */
+
 package nl.digitalekabeltelevisie.data.mpeg.descriptors.extension.mpeg;
 
 import static nl.digitalekabeltelevisie.util.Utils.MASK_1BIT;
@@ -6,15 +33,16 @@ import static nl.digitalekabeltelevisie.util.Utils.MASK_7BITS;
 import static nl.digitalekabeltelevisie.util.Utils.getInt;
 import static nl.digitalekabeltelevisie.util.Utils.getLong;
 
-import javax.swing.tree.DefaultMutableTreeNode;
 
 import nl.digitalekabeltelevisie.controller.KVP;
 import nl.digitalekabeltelevisie.data.mpeg.psi.TableSection;
 
+// based on 2.6.97 HEVC timing and HRD descriptor Rec. ITU-T H.222.0 (06/2021)
+
 public class HEVCTimingAndHRDDescriptor extends MPEGExtensionDescriptor {
 
 	private final int hrd_management_valid_flag;
-	private final int reserved1;
+	private final int target_schedule_idx;
 	private final int picture_and_timing_info_present;
 
 	private int _90kHz_flag;
@@ -22,45 +50,51 @@ public class HEVCTimingAndHRDDescriptor extends MPEGExtensionDescriptor {
 	private long n;
 	private long k;
 	private long num_units_in_tick;
+	private int target_schedule_idx_not_present_flag;
 	
-	public HEVCTimingAndHRDDescriptor(byte[] b, int offset, TableSection parent) {
-		super(b, offset, parent);
-		hrd_management_valid_flag = getInt(b, offset+2, 1, 0x80)>>>7;
-		reserved1 = getInt(b, offset+2, 1, 0x7e)>>>1;
-		picture_and_timing_info_present = getInt(b, offset+2, 1, MASK_1BIT);
+	public HEVCTimingAndHRDDescriptor(byte[] b, TableSection parent) {
+		super(b, parent);
+		hrd_management_valid_flag = getInt(b, 3, 1, 0b1000_0000)>>>7;
+		target_schedule_idx_not_present_flag  = getInt(b, 3, 1, 0b0100_0000)>>>6;
+		target_schedule_idx = getInt(b, 3, 1, 0b0011_1110)>>>1;
+		picture_and_timing_info_present = getInt(b, 3, 1, MASK_1BIT);
 		int t=0;
 		if(picture_and_timing_info_present==1){
-			_90kHz_flag = getInt(b, offset+3, 1, 0x80)>>>7;
-			reserved2 = getInt(b, offset+3, 1, MASK_7BITS);
+			_90kHz_flag = getInt(b, 4, 1, 0x80)>>>7;
+			reserved2 = getInt(b, 4, 1, MASK_7BITS);
 			t+=1;
 			if(_90kHz_flag==0){
-				n = getLong(b, offset+4, 4, MASK_32BITS);
-				k = getLong(b, offset+8, 4, MASK_32BITS);
+				n = getLong(b, 5, 4, MASK_32BITS);
+				k = getLong(b, 9, 4, MASK_32BITS);
 				t+=8;
 			}
-			num_units_in_tick = getLong(b, offset+3+t, 4, MASK_32BITS);
+			num_units_in_tick = getLong(b, 4+t, 4, MASK_32BITS);
 		}
 	}
 
 	@Override
-	public DefaultMutableTreeNode getJTreeNode(final int modus){
-		final DefaultMutableTreeNode t = super.getJTreeNode(modus);
-		t.add(new DefaultMutableTreeNode(new KVP("hrd_management_valid_flag",hrd_management_valid_flag,
-				hrd_management_valid_flag == 1
-				? "Buffering Period SEI and Picture Timing SEI messages shall be present in the associated HEVC video stream"
-				: "leak method shall be used for the transfer from MBn to EBn")));
-		t.add(new DefaultMutableTreeNode(new KVP("reserved1",reserved1,null)));
-		t.add(new DefaultMutableTreeNode(new KVP("picture_and_timing_info_present",picture_and_timing_info_present,null)));
-		if(picture_and_timing_info_present==1){
-			t.add(new DefaultMutableTreeNode(new KVP("90kHz_flag",_90kHz_flag,null)));
-			t.add(new DefaultMutableTreeNode(new KVP("reserved2",reserved2,null)));
-			if(_90kHz_flag==0){
-				t.add(new DefaultMutableTreeNode(new KVP("n",n,null)));
-				t.add(new DefaultMutableTreeNode(new KVP("k",k,null)));
+	public KVP getJTreeNode(final int modus){
+		final KVP t = super.getJTreeNode(modus);
+		t.add(new KVP("hrd_management_valid_flag", hrd_management_valid_flag).setDescription(getHrdManagmentDescription()));
+		t.add(new KVP("target_schedule_idx_not_present_flag", target_schedule_idx_not_present_flag));
+		t.add(new KVP("target_schedule_idx", target_schedule_idx));
+		t.add(new KVP("picture_and_timing_info_present", picture_and_timing_info_present));
+		if (picture_and_timing_info_present == 1) {
+			t.add(new KVP("90kHz_flag", _90kHz_flag));
+			t.add(new KVP("reserved2", reserved2));
+			if (_90kHz_flag == 0) {
+				t.add(new KVP("n", n));
+				t.add(new KVP("k", k));
 			}
-			t.add(new DefaultMutableTreeNode(new KVP("num_units_in_tick",num_units_in_tick,null)));
+			t.add(new KVP("num_units_in_tick", num_units_in_tick));
 
 		}
 		return t;
+	}
+
+	private String getHrdManagmentDescription() {
+		return hrd_management_valid_flag == 1
+				? "Buffering Period SEI and Picture Timing SEI messages shall be present in the associated HEVC video stream"
+				: "leak method shall be used for the transfer from MBn to EBn";
 	}
 }

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/extension/mpeg/JpegXsVideoDescriptor.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/extension/mpeg/JpegXsVideoDescriptor.java
@@ -30,7 +30,6 @@ import nl.digitalekabeltelevisie.controller.KVP;
 import nl.digitalekabeltelevisie.data.mpeg.psi.TableSection;
 import nl.digitalekabeltelevisie.util.BitSource;
 
-import javax.swing.tree.DefaultMutableTreeNode;
 
 /**
  * Class responsible for decoding a JPEG-XS video descriptor from a byte array
@@ -71,10 +70,10 @@ public class JpegXsVideoDescriptor extends MPEGExtensionDescriptor {
 	private int maxcll;
 	private int maxfall;
 
-    public JpegXsVideoDescriptor(byte[] b, int offset, TableSection parent) {
-        super(b, offset, parent);
+    public JpegXsVideoDescriptor(byte[] b, TableSection parent) {
+        super(b, parent);
 
-        BitSource reader = new BitSource(b, offset + 3);
+        BitSource reader = new BitSource(b, 3);
         descriptor_version = reader.readBitsLong(8);
         horizontal_size = reader.readBitsLong(16);
         vertical_size = reader.readBitsLong(16);
@@ -117,103 +116,102 @@ public class JpegXsVideoDescriptor extends MPEGExtensionDescriptor {
     }
 
     @Override
-    public DefaultMutableTreeNode getJTreeNode(int modus) {
-        final DefaultMutableTreeNode t = new DefaultMutableTreeNode(new KVP("JPEG-XS Descriptor"));
-        t.add(new DefaultMutableTreeNode(new KVP("descriptor_version", descriptor_version, null)));
-        t.add(new DefaultMutableTreeNode(new KVP("horizontal_size", horizontal_size, null)));
-        t.add(new DefaultMutableTreeNode(new KVP("vertical_size", vertical_size, null)));
-        t.add(new DefaultMutableTreeNode(new KVP("brat", brat, "Bit Rate (MBits/s)")));
+    public KVP getJTreeNode(int modus) {
+		final KVP t = super.getJTreeNode(modus);
+
+        t.add(new KVP("descriptor_version", descriptor_version));
+        t.add(new KVP("horizontal_size", horizontal_size));
+        t.add(new KVP("vertical_size", vertical_size));
+        t.add(new KVP("brat", brat, "Bit Rate (MBits/s)"));
         t.add(buildFratNode(frat));
         t.add(buildScharNode(schar));
         t.add(buildPpihNode(ppih));
         t.add(buildPlevNode(plev));
-        t.add(new DefaultMutableTreeNode(new KVP("max_buffer_size", max_buffer_size, "Maximum buffer size (Mbits/s)")));
-        t.add(new DefaultMutableTreeNode(new KVP("buffer_model_type", buffer_model_type, null)));
-        t.add(new DefaultMutableTreeNode(new KVP("colour_primaries", colour_primaries, null)));
-        t.add(new DefaultMutableTreeNode(new KVP("transfer_characteristics", transfer_characteristics, null)));
-        t.add(new DefaultMutableTreeNode(new KVP("matrix_coefficients", matrix_coefficients, null)));
-        t.add(new DefaultMutableTreeNode(new KVP("video_full_range_flag", video_full_range_flag, null)));
-        t.add(new DefaultMutableTreeNode(new KVP("still_mode", still_mode, null)));
-        t.add(new DefaultMutableTreeNode(new KVP("mdm_flag", mdm_flag, null)));
-        t.add(new DefaultMutableTreeNode(new KVP("zero_bits", zero_bits, null)));
+        t.add(new KVP("max_buffer_size", max_buffer_size, "Maximum buffer size (Mbits/s)"));
+        t.add(new KVP("buffer_model_type", buffer_model_type));
+        t.add(new KVP("colour_primaries", colour_primaries));
+        t.add(new KVP("transfer_characteristics", transfer_characteristics));
+        t.add(new KVP("matrix_coefficients", matrix_coefficients));
+        t.add(new KVP("video_full_range_flag", video_full_range_flag, null));
+        t.add(new KVP("still_mode", still_mode, null));
+        t.add(new KVP("mdm_flag", mdm_flag, null));
+        t.add(new KVP("zero_bits", zero_bits));
  
         if(mdm_flag) {
-            t.add(new DefaultMutableTreeNode(new KVP("X_c0", x_c0, null)));
-            t.add(new DefaultMutableTreeNode(new KVP("Y_c0", y_c0, null)));
-            t.add(new DefaultMutableTreeNode(new KVP("X_c1", x_c1, null)));
-            t.add(new DefaultMutableTreeNode(new KVP("Y_c1", y_c1, null)));
-            t.add(new DefaultMutableTreeNode(new KVP("X_c2", x_c2, null)));
-            t.add(new DefaultMutableTreeNode(new KVP("Y_c2", y_c2, null)));
-            t.add(new DefaultMutableTreeNode(new KVP("X_wp", x_wp, null)));
-            t.add(new DefaultMutableTreeNode(new KVP("Y_wp", y_wp, null)));
-            t.add(new DefaultMutableTreeNode(new KVP("L_max", l_max, null)));
-            t.add(new DefaultMutableTreeNode(new KVP("L_min", l_min, null)));
-            t.add(new DefaultMutableTreeNode(new KVP("MaxCLL", maxcll, null)));
-            t.add(new DefaultMutableTreeNode(new KVP("MaxFALL", maxfall, null)));
+            t.add(new KVP("X_c0", x_c0));
+            t.add(new KVP("Y_c0", y_c0));
+            t.add(new KVP("X_c1", x_c1));
+            t.add(new KVP("Y_c1", y_c1));
+            t.add(new KVP("X_c2", x_c2));
+            t.add(new KVP("Y_c2", y_c2));
+            t.add(new KVP("X_wp", x_wp));
+            t.add(new KVP("Y_wp", y_wp));
+            t.add(new KVP("L_max", l_max));
+            t.add(new KVP("L_min", l_min));
+            t.add(new KVP("MaxCLL", maxcll));
+            t.add(new KVP("MaxFALL", maxfall));
         	
         }
         	 
         
-        t.add(new DefaultMutableTreeNode(new KVP("private_data", private_data, null)));
-        final DefaultMutableTreeNode parentNode = super.getJTreeNode(modus);
-        parentNode.add(t);
-        return parentNode;
+        t.add(new KVP("private_data", private_data));
+        return t;
     }
 
-    public static DefaultMutableTreeNode buildFratNode(long frat) {
-        final DefaultMutableTreeNode fratNode = new DefaultMutableTreeNode(new KVP("frat", frat, "Frame rate"));
+    public static KVP buildFratNode(long frat) {
+        final KVP fratNode = new KVP("frat", frat, "Frame rate");
 
         final long interlaceMode = (frat >> 30) & 0x3;
         final String interlaceText = interlaceMode == 0 ? "Progressive frame (frame contains one full-height picture)"
                 : interlaceMode == 1 ? "Interlaced frame (picture is first video field)"
                 : interlaceMode == 2 ? "Interlaced frame (picture is second video field)"
                 : "Reserved";
-        fratNode.add(new DefaultMutableTreeNode(new KVP("interlace_mode", interlaceMode, interlaceText)));
+        fratNode.add(new KVP("interlace_mode", interlaceMode, interlaceText));
 
         final long framerateDenominator = (frat >> 24) & 0x3F;
         final String denominatorText = framerateDenominator == 1 ? "Value=1.000"
                 : framerateDenominator == 2 ? "Value=1.001"
                 : "Reserved";
-        fratNode.add(new DefaultMutableTreeNode(new KVP("framerate_denominator", framerateDenominator, denominatorText)));
+        fratNode.add(new KVP("framerate_denominator", framerateDenominator, denominatorText));
 
         final long framerateNumerator = frat & 0xFFFF;
         final String numeratorText = "Frames/sec";
-        fratNode.add(new DefaultMutableTreeNode(new KVP("framerate_numerator", framerateNumerator, numeratorText)));
+        fratNode.add(new KVP("framerate_numerator", framerateNumerator, numeratorText));
 
         return fratNode;
     }
 
-    public static DefaultMutableTreeNode buildScharNode(long schar) {
-        final DefaultMutableTreeNode scharNode = new DefaultMutableTreeNode(new KVP("schar", schar, "Sampling characteristics"));
+    public static KVP buildScharNode(long schar) {
+        final KVP scharNode = new KVP("schar", schar, "Sampling characteristics");
 
         final long validFlag = (schar >> 15) & 0x1;
         final String validText = validFlag == 0 ? "Invalid" : "Valid";
-        scharNode.add(new DefaultMutableTreeNode(new KVP("valid_flag", validFlag, validText)));
+        scharNode.add(new KVP("valid_flag", validFlag, validText));
 
         final long sampleBitDepth = (schar >> 4) & 0xF;
-        scharNode.add(new DefaultMutableTreeNode(new KVP("sample_bitdepth", sampleBitDepth, null)));
+        scharNode.add(new KVP("sample_bitdepth", sampleBitDepth));
 
         final long samplingStructure = schar & 0xF;
         final String samplingStructureText = samplingStructureToString(samplingStructure);
-        scharNode.add(new DefaultMutableTreeNode(new KVP("sampling_structure", samplingStructure, samplingStructureText)));
+        scharNode.add(new KVP("sampling_structure", samplingStructure, samplingStructureText));
 
         return scharNode;
     }
 
-    public static DefaultMutableTreeNode buildPpihNode(long ppih) {
-        return new DefaultMutableTreeNode(new KVP("ppih", ppih, ppihToString(ppih)));
+    public static KVP buildPpihNode(long ppih) {
+        return new KVP("ppih", ppih, ppihToString(ppih));
     }
 
-    public static DefaultMutableTreeNode buildPlevNode(long plev) {
-        DefaultMutableTreeNode plevNode = new DefaultMutableTreeNode(new KVP("plev", plev, null));
+    public static KVP buildPlevNode(long plev) {
+    	KVP plevNode = new KVP("plev", plev);
 
         final long level = (plev >> 8) & 0xFF;
         final String levelText = getLevelText(level);
-        plevNode.add(new DefaultMutableTreeNode(new KVP("level", level, levelText)));
+        plevNode.add(new KVP("level", level, levelText));
 
         final long subLevel = plev & 0xFF;
         final String subLevelText = getSubLevelText(subLevel);
-        plevNode.add(new DefaultMutableTreeNode(new KVP("sub_level", subLevel, subLevelText)));
+        plevNode.add(new KVP("sub_level", subLevel, subLevelText));
 
         return plevNode;
     }

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/extension/mpeg/JpegXsVideoDescriptor.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/extension/mpeg/JpegXsVideoDescriptor.java
@@ -52,9 +52,9 @@ public class JpegXsVideoDescriptor extends MPEGExtensionDescriptor {
     private final long colour_primaries;
     private final long transfer_characteristics;
     private final long matrix_coefficients;
-    private final boolean video_full_range_flag;
-    private final boolean still_mode;
-    private final boolean mdm_flag;
+    private final int video_full_range_flag;
+    private final int still_mode;
+    private final int mdm_flag;
     private final byte[] private_data;
 	private final int zero_bits;
 	private int x_c0;
@@ -87,13 +87,13 @@ public class JpegXsVideoDescriptor extends MPEGExtensionDescriptor {
         colour_primaries = reader.readBitsLong(8);
         transfer_characteristics = reader.readBitsLong(8);
         matrix_coefficients = reader.readBitsLong(8);
-        video_full_range_flag = reader.readBits(1) == 1;
+        video_full_range_flag = reader.readBits(1);
         reader.skiptoByteBoundary();
-        still_mode = reader.readBits(1) == 1;
-        mdm_flag = reader.readBits(1) == 1;
+        still_mode = reader.readBits(1);
+        mdm_flag = reader.readBits(1);
         
         zero_bits = reader.readBits(6);
-        if(mdm_flag) {
+        if(mdm_flag == 1) {
         	
         	x_c0 = reader.readBits(16);
         	y_c0 = reader.readBits(16);
@@ -132,12 +132,12 @@ public class JpegXsVideoDescriptor extends MPEGExtensionDescriptor {
         t.add(new KVP("colour_primaries", colour_primaries));
         t.add(new KVP("transfer_characteristics", transfer_characteristics));
         t.add(new KVP("matrix_coefficients", matrix_coefficients));
-        t.add(new KVP("video_full_range_flag", video_full_range_flag, null));
-        t.add(new KVP("still_mode", still_mode, null));
-        t.add(new KVP("mdm_flag", mdm_flag, null));
+        t.add(new KVP("video_full_range_flag", video_full_range_flag));
+        t.add(new KVP("still_mode", still_mode));
+        t.add(new KVP("mdm_flag", mdm_flag));
         t.add(new KVP("zero_bits", zero_bits));
  
-        if(mdm_flag) {
+        if(mdm_flag == 1) {
             t.add(new KVP("X_c0", x_c0));
             t.add(new KVP("Y_c0", y_c0));
             t.add(new KVP("X_c1", x_c1));

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/extension/mpeg/MPEGExtensionDescriptor.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/extension/mpeg/MPEGExtensionDescriptor.java
@@ -33,7 +33,11 @@ import nl.digitalekabeltelevisie.data.mpeg.psi.TableSection;
 public class MPEGExtensionDescriptor extends ExtensionDescriptor {
 
 	public MPEGExtensionDescriptor(byte[] b, int offset, TableSection parent) {
-		super(b, offset, parent);
+		super(b, parent);
+	}
+
+	public MPEGExtensionDescriptor(byte[] b, TableSection parent) {
+		super(b, parent);
 	}
 
 	public static String getDescriptorTagString(final int descriptor_tag_extension) {

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/extension/mpeg/MPEGExtensionDescriptor.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/extension/mpeg/MPEGExtensionDescriptor.java
@@ -1,32 +1,33 @@
+/**
+ *
+ *  http://www.digitalekabeltelevisie.nl/dvb_inspector
+ *
+ *  This code is Copyright 2009-2024 by Eric Berendsen (e_berendsen@digitalekabeltelevisie.nl)
+ *
+ *  This file is part of DVB Inspector.
+ *
+ *  DVB Inspector is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  DVB Inspector is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with DVB Inspector.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  The author requests that he be notified of any application, applet, or
+ *  other binary that makes use of this code, but that's more out of curiosity
+ *  than anything and is not required.
+ *
+ */
+
 package nl.digitalekabeltelevisie.data.mpeg.descriptors.extension.mpeg;
 
-/**
-*
-*  http://www.digitalekabeltelevisie.nl/dvb_inspector
-*
-*  This code is Copyright 2009-2024 by Eric Berendsen (e_berendsen@digitalekabeltelevisie.nl)
-*
-*  This file is part of DVB Inspector.
-*
-*  DVB Inspector is free software: you can redistribute it and/or modify
-*  it under the terms of the GNU General Public License as published by
-*  the Free Software Foundation, either version 3 of the License, or
-*  (at your option) any later version.
-*
-*  DVB Inspector is distributed in the hope that it will be useful,
-*  but WITHOUT ANY WARRANTY; without even the implied warranty of
-*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-*  GNU General Public License for more details.
-*
-*  You should have received a copy of the GNU General Public License
-*  along with DVB Inspector.  If not, see <http://www.gnu.org/licenses/>.
-*
-*  The author requests that he be notified of any application, applet, or
-*  other binary that makes use of this code, but that's more out of curiosity
-*  than anything and is not required.
-*
-*/
-
+import nl.digitalekabeltelevisie.controller.KVP;
 import nl.digitalekabeltelevisie.data.mpeg.descriptors.ExtensionDescriptor;
 import nl.digitalekabeltelevisie.data.mpeg.psi.TableSection;
 
@@ -104,5 +105,11 @@ public class MPEGExtensionDescriptor extends ExtensionDescriptor {
 	public String getDescriptorTagString() {
 		return getDescriptorTagString(descriptor_tag_extension);
 	}
+	
+	@Override
+	public KVP getJTreeNode(int modus){
+		return (KVP) super.getJTreeNode(modus);
+	}
+
 
 }

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/intable/INTDescriptor.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/intable/INTDescriptor.java
@@ -27,6 +27,7 @@
 
 package nl.digitalekabeltelevisie.data.mpeg.descriptors.intable;
 
+import nl.digitalekabeltelevisie.controller.KVP;
 import nl.digitalekabeltelevisie.data.mpeg.descriptors.Descriptor;
 import nl.digitalekabeltelevisie.data.mpeg.psi.TableSection;
 
@@ -47,8 +48,8 @@ public class INTDescriptor extends Descriptor {
 	 * @param offset
 	 * @param parent
 	 */
-	public INTDescriptor(final byte[] b, final int offset, final TableSection parent) {
-		super(b, offset, parent);
+	public INTDescriptor(byte[] b, TableSection parent) {
+		super(b, parent);
 	}
 
 	@Override
@@ -56,7 +57,13 @@ public class INTDescriptor extends Descriptor {
 		return INTDescriptor.getDescriptorname(descriptorTag, parentTableSection);
 	}
 
-	public static String getDescriptorname(final int tag, final TableSection tableSection){
+	@Override
+	public KVP getJTreeNode(int modus){
+		return (KVP)super.getJTreeNode(modus);
+	}
+	
+	
+	public static String getDescriptorname(int tag, TableSection tableSection){
 
 
 

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/intable/IPMACPlatformNameDescriptor.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/intable/IPMACPlatformNameDescriptor.java
@@ -29,8 +29,6 @@ package nl.digitalekabeltelevisie.data.mpeg.descriptors.intable;
 
 import static nl.digitalekabeltelevisie.util.Utils.getISO8859_1String;
 
-import javax.swing.tree.DefaultMutableTreeNode;
-
 import nl.digitalekabeltelevisie.controller.DVBString;
 import nl.digitalekabeltelevisie.controller.KVP;
 import nl.digitalekabeltelevisie.data.mpeg.psi.TableSection;
@@ -49,18 +47,18 @@ public class IPMACPlatformNameDescriptor extends INTDescriptor {
 	 * @param offset
 	 * @param parent
 	 */
-	public IPMACPlatformNameDescriptor(final byte[] b, final int offset, final TableSection parent) {
-		super(b, offset, parent);
-		iso639LanguageCode = getISO8859_1String(b, offset + 2, 3);
-		text = new DVBString(b, offset + 5, descriptorLength - 3);
+	public IPMACPlatformNameDescriptor(byte[] b, TableSection parent) {
+		super(b,  parent);
+		iso639LanguageCode = getISO8859_1String(b, 2, 3);
+		text = new DVBString(b, 5, descriptorLength - 3);
 
 	}
 
 	@Override
-	public DefaultMutableTreeNode getJTreeNode(final int modus) {
-		final DefaultMutableTreeNode t = super.getJTreeNode(modus);
-		t.add(new DefaultMutableTreeNode(new KVP("ISO_639_language_code", iso639LanguageCode, null)));
-		t.add(new DefaultMutableTreeNode(new KVP("platform name", text, null)));
+	public KVP getJTreeNode(int modus) {
+		final KVP t = super.getJTreeNode(modus);
+		t.add(new KVP("ISO_639_language_code", iso639LanguageCode));
+		t.add(new KVP("platform name", text));
 		return t;
 	}
 

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/intable/IPMACPlatformProviderNameDescriptor.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/intable/IPMACPlatformProviderNameDescriptor.java
@@ -29,8 +29,6 @@ package nl.digitalekabeltelevisie.data.mpeg.descriptors.intable;
 
 import static nl.digitalekabeltelevisie.util.Utils.getISO8859_1String;
 
-import javax.swing.tree.DefaultMutableTreeNode;
-
 import nl.digitalekabeltelevisie.controller.DVBString;
 import nl.digitalekabeltelevisie.controller.KVP;
 import nl.digitalekabeltelevisie.data.mpeg.psi.TableSection;
@@ -49,20 +47,19 @@ public class IPMACPlatformProviderNameDescriptor extends INTDescriptor {
 	 * @param offset
 	 * @param parent
 	 */
-	public IPMACPlatformProviderNameDescriptor(final byte[] b, final int offset, final TableSection parent) {
-		super(b, offset, parent);
-		iso639LanguageCode = getISO8859_1String(b, offset + 2, 3);
-		text = new DVBString(b, offset + 5, descriptorLength - 3);
+	public IPMACPlatformProviderNameDescriptor(byte[] b, TableSection parent) {
+		super(b, parent);
+		iso639LanguageCode = getISO8859_1String(b, 2, 3);
+		text = new DVBString(b, 5, descriptorLength - 3);
 
 	}
 
 	@Override
-	public DefaultMutableTreeNode getJTreeNode(final int modus) {
-		final DefaultMutableTreeNode t = super.getJTreeNode(modus);
-		t.add(new DefaultMutableTreeNode(new KVP("ISO_639_language_code", iso639LanguageCode, null)));
-		t.add(new DefaultMutableTreeNode(new KVP("platform name", text, null)));
+	public KVP getJTreeNode(int modus) {
+		final KVP t = super.getJTreeNode(modus);
+		t.add(new KVP("ISO_639_language_code", iso639LanguageCode));
+		t.add(new KVP("platform name", text));
 		return t;
 	}
-
 
 }

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/intable/IPMACStreamLocationDescriptor.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/intable/IPMACStreamLocationDescriptor.java
@@ -31,8 +31,6 @@ import static nl.digitalekabeltelevisie.util.Utils.MASK_16BITS;
 import static nl.digitalekabeltelevisie.util.Utils.MASK_8BITS;
 import static nl.digitalekabeltelevisie.util.Utils.getInt;
 
-import javax.swing.tree.DefaultMutableTreeNode;
-
 import nl.digitalekabeltelevisie.controller.KVP;
 import nl.digitalekabeltelevisie.data.mpeg.psi.TableSection;
 import nl.digitalekabeltelevisie.util.Utils;
@@ -49,13 +47,13 @@ public class IPMACStreamLocationDescriptor extends INTDescriptor {
 
 
 
-	public IPMACStreamLocationDescriptor(final byte[] b, final int offset, final TableSection parent) {
-		super(b, offset,parent);
-		networkId = getInt(b,offset+2,2,MASK_16BITS);
-		originalNetworkId = getInt(b,offset+4,2,MASK_16BITS);
-		transportStreamId = getInt(b,offset+6,2,MASK_16BITS);
-		serviceId = getInt(b,offset+8,2,MASK_16BITS);
-		componentTag = getInt(b,offset+10,1,MASK_8BITS);
+	public IPMACStreamLocationDescriptor(byte[] b, TableSection parent) {
+		super(b, parent);
+		networkId = getInt(b, 2, 2, MASK_16BITS);
+		originalNetworkId = getInt(b, 4, 2, MASK_16BITS);
+		transportStreamId = getInt(b, 6, 2, MASK_16BITS);
+		serviceId = getInt(b, 8, 2, MASK_16BITS);
+		componentTag = getInt(b, 10, 1, MASK_8BITS);
 	}
 
 	@Override
@@ -64,14 +62,14 @@ public class IPMACStreamLocationDescriptor extends INTDescriptor {
 	}
 
 	@Override
-	public DefaultMutableTreeNode getJTreeNode(final int modus){
-		final var treeNode = super.getJTreeNode(modus);
+	public KVP getJTreeNode(int modus){
+		final KVP treeNode = super.getJTreeNode(modus);
 		final var psi = parentTableSection.getParentPID().getParentTransportStream().getPsi();
-		treeNode.add(new DefaultMutableTreeNode(new KVP("network_id",networkId ,psi.getNit().getNetworkName(networkId))));
-		treeNode.add(new DefaultMutableTreeNode(new KVP("original_network_id",originalNetworkId ,Utils.getOriginalNetworkIDString(originalNetworkId))));
-		treeNode.add(new DefaultMutableTreeNode(new KVP("transport_stream_id",transportStreamId ,null)));
-		treeNode.add(new DefaultMutableTreeNode(new KVP("service_id",serviceId ,psi.getSdt().getServiceName(originalNetworkId, transportStreamId, serviceId))));
-		treeNode.add(new DefaultMutableTreeNode(new KVP("component_tag",componentTag ,null)));
+		treeNode.add(new KVP("network_id",networkId ,psi.getNit().getNetworkName(networkId)));
+		treeNode.add(new KVP("original_network_id",originalNetworkId ,Utils.getOriginalNetworkIDString(originalNetworkId)));
+		treeNode.add(new KVP("transport_stream_id",transportStreamId));
+		treeNode.add(new KVP("service_id",serviceId ,psi.getSdt().getServiceName(originalNetworkId, transportStreamId, serviceId)));
+		treeNode.add(new KVP("component_tag",componentTag));
 		return treeNode;
 	}
 
@@ -79,21 +77,8 @@ public class IPMACStreamLocationDescriptor extends INTDescriptor {
 		return originalNetworkId;
 	}
 
-
-	public void setOriginalNetworkId(final int caPID) {
-		this.originalNetworkId = caPID;
-	}
-
 	public int getTransportStreamId() {
 		return transportStreamId;
 	}
-
-	public void setTransportStreamId(final int caSystemID) {
-		this.transportStreamId = caSystemID;
-	}
-
-
-
-
 
 }

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/intable/TargetIPSlashDescriptor.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/intable/TargetIPSlashDescriptor.java
@@ -43,24 +43,16 @@ import nl.digitalekabeltelevisie.util.Utils;
  */
 public class TargetIPSlashDescriptor extends INTDescriptor {
 
-	private List<IPAdress> ipList = new ArrayList<IPAdress>();
+	private List<IPAdress> ipList = new ArrayList<>();
 
+	public static record IPAdress(byte[] IPv4_addr, int IPv4_slash_mask) implements TreeNode {
 
-	public static class IPAdress implements TreeNode{
-
-		private final byte[]IPv4_addr;
-		private final int IPv4_slash_mask;
-
-		public IPAdress(final byte[] pv4_addr, final int pv4_slash_mask) {
-			super();
-			IPv4_addr = pv4_addr;
-			IPv4_slash_mask = pv4_slash_mask;
-		}
-
-		public DefaultMutableTreeNode getJTreeNode(final int modus){
-			final DefaultMutableTreeNode s=new DefaultMutableTreeNode(new KVP("ip-adress(es) "+Utils.formatIPNumber(IPv4_addr)+"/"+IPv4_slash_mask));
-			s.add(new DefaultMutableTreeNode(new KVP("IPv4_addr",IPv4_addr,Utils.formatIPNumber(IPv4_addr))));
-			s.add(new DefaultMutableTreeNode(new KVP("IPv4_slash_mask",IPv4_slash_mask,null)));
+		@Override
+		public DefaultMutableTreeNode getJTreeNode(int modus) {
+			final DefaultMutableTreeNode s = new DefaultMutableTreeNode(
+					new KVP("ip-adress(es) " + Utils.formatIPNumber(IPv4_addr) + "/" + IPv4_slash_mask));
+			s.add(new DefaultMutableTreeNode(new KVP("IPv4_addr", IPv4_addr, Utils.formatIPNumber(IPv4_addr))));
+			s.add(new DefaultMutableTreeNode(new KVP("IPv4_slash_mask", IPv4_slash_mask, null)));
 			return s;
 		}
 
@@ -71,12 +63,12 @@ public class TargetIPSlashDescriptor extends INTDescriptor {
 	 * @param offset
 	 * @param parent
 	 */
-	public TargetIPSlashDescriptor(final byte[] b, final int offset, final TableSection parent) {
-		super(b, offset, parent);
+	public TargetIPSlashDescriptor(byte[] b, TableSection parent) {
+		super(b, parent);
 		int t = 0;
 		while (t<descriptorLength) {
-			final byte[] adress = Utils.getBytes(b, offset+2+t, 4);
-			final int mask  = Utils.getInt(b, offset+6+t, 1, 0xFF);
+			final byte[] adress = Utils.getBytes(b, 2+t, 4);
+			final int mask  = Utils.getInt(b, 6+t, 1, 0xFF);
 			final IPAdress a = new IPAdress(adress,mask);
 			ipList.add(a);
 			t+=5;
@@ -84,9 +76,9 @@ public class TargetIPSlashDescriptor extends INTDescriptor {
 	}
 
 	@Override
-	public DefaultMutableTreeNode getJTreeNode(final int modus){
+	public KVP getJTreeNode(int modus){
 
-		final DefaultMutableTreeNode t = super.getJTreeNode(modus);
+		final KVP t = super.getJTreeNode(modus);
 		Utils.addListJTree(t,ipList,modus,"ip_list");
 		return t;
 	}

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/privatedescriptors/canal_international/CosBatSelectionDescriptor.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/privatedescriptors/canal_international/CosBatSelectionDescriptor.java
@@ -46,19 +46,18 @@ public class CosBatSelectionDescriptor extends Descriptor {
 
 	/**
 	 * @param b
-	 * @param offset
 	 * @param parent
 	 */
-	public CosBatSelectionDescriptor(byte[] b, int offset, TableSection parent) {
-		super(b, offset, parent);
-		bouquet_id = getInt(b, offset+2,2,MASK_16BITS);
-		selector_type = getInt(b, offset+4,1,MASK_8BITS);
-		if (selector_type == 0x01) { 
-			usage_id = getInt(b, offset+5,1,MASK_8BITS);
-		}else if (selector_type == 0x02) { 
-			region_name = new DVBString (b,offset+5);
-		}else if (selector_type != 0x03) { 
-			databyte = getBytes(b, offset+5, descriptorLength -3);
+	public CosBatSelectionDescriptor(byte[] b, TableSection parent) {
+		super(b, parent);
+		bouquet_id = getInt(b, 2, 2, MASK_16BITS);
+		selector_type = getInt(b, 4, 1, MASK_8BITS);
+		if (selector_type == 0x01) {
+			usage_id = getInt(b, 5, 1, MASK_8BITS);
+		} else if (selector_type == 0x02) {
+			region_name = new DVBString(b, 5);
+		} else if (selector_type != 0x03) {
+			databyte = getBytes(b, 5, descriptorLength - 3);
 		}
 	}
 
@@ -68,21 +67,19 @@ public class CosBatSelectionDescriptor extends Descriptor {
 	}
 	
 	@Override
-	public DefaultMutableTreeNode getJTreeNode(final int modus){
+	public DefaultMutableTreeNode getJTreeNode(int modus) {
 
-		final DefaultMutableTreeNode t = super.getJTreeNode(modus);
-		t.add(new DefaultMutableTreeNode(new KVP("bouquet_id",bouquet_id,null)));
-		t.add(new DefaultMutableTreeNode(new KVP("selector_type",selector_type,getSelectorTypeString(selector_type))));
-		if (selector_type == 0x01) { 
-			t.add(new DefaultMutableTreeNode(new KVP("usage_id",usage_id,null)));
-		}else if (selector_type == 0x02) { 
-			t.add(new DefaultMutableTreeNode(new KVP("region_name_length",region_name.getLength(),null)));
-			t.add(new DefaultMutableTreeNode(new KVP("region_name",region_name,null)));
-		}else if (selector_type != 0x03) { 
-			t.add(new DefaultMutableTreeNode(new KVP("databyte",databyte,null)));
+		DefaultMutableTreeNode t = super.getJTreeNode(modus);
+		t.add(new KVP("bouquet_id", bouquet_id));
+		t.add(new KVP("selector_type", selector_type).setDescription(getSelectorTypeString(selector_type)));
+		if (selector_type == 0x01) {
+			t.add(new KVP("usage_id", usage_id));
+		} else if (selector_type == 0x02) {
+			t.add(new KVP("region_name", region_name));
+		} else if (selector_type != 0x03) {
+			t.add(new KVP("databyte", databyte));
 
 		}
-
 
 		return t;
 	}

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/privatedescriptors/canal_international/CosTimezoneDescriptor.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/privatedescriptors/canal_international/CosTimezoneDescriptor.java
@@ -47,16 +47,15 @@ public class CosTimezoneDescriptor extends Descriptor {
 	
 	private List<TimezoneName> timezoneNames = new ArrayList<>();
 	
-	public record TimezoneName(String country_code, int country_region_id, int reserved, DVBString region_name) implements TreeNode{
+	public record TimezoneName(String country_code, int country_region_id, int reserved, DVBString region_name) implements TreeNode {
 
 		@Override
-		public DefaultMutableTreeNode getJTreeNode(final int modus){
-			final DefaultMutableTreeNode s=new DefaultMutableTreeNode(new KVP("TimezoneName"));
-			s.add(new DefaultMutableTreeNode(new KVP("country_code",country_code,null)));
-			s.add(new DefaultMutableTreeNode(new KVP("country_region_id",country_region_id,null)));
-			s.add(new DefaultMutableTreeNode(new KVP("reserved",reserved,null)));
-			s.add(new DefaultMutableTreeNode(new KVP("region_name_length",region_name.getLength(),null)));
-			s.add(new DefaultMutableTreeNode(new KVP("region_name",region_name,null)));
+		public KVP getJTreeNode(final int modus) {
+			final KVP s = new KVP("TimezoneName");
+			s.add(new KVP("country_code", country_code));
+			s.add(new KVP("country_region_id", country_region_id));
+			s.add(new KVP("reserved", reserved, null));
+			s.add(new KVP("region_name", region_name));
 			return s;
 		}
 	}

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/privatedescriptors/dtg/GuidanceDescriptor.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/privatedescriptors/dtg/GuidanceDescriptor.java
@@ -50,40 +50,41 @@ public class GuidanceDescriptor extends Descriptor  {
 	byte[] reserved_for_future_use;
 
 
-	public GuidanceDescriptor(final byte[] b, final int offset, final TableSection parent) {
-		super(b, offset,parent);
-		reserved = getInt(b, offset+2, 1, 0xFC)>>2;
-		guidance_type = getInt(b, offset+2, 1, MASK_2BITS);
+	public GuidanceDescriptor( byte[] b, TableSection parent) {
+		super(b, parent);
+		reserved = getInt(b, 2, 1, 0xFC)>>2;
+		guidance_type = getInt(b, 2, 1, MASK_2BITS);
 		if(guidance_type==0){
-			iso_639_language_code=getISO8859_1String(b, offset+3, 3);
-			guidance_char = new DVBString(b, offset+6, descriptorLength-4);
+			iso_639_language_code=getISO8859_1String(b, 3, 3);
+			guidance_char = new DVBString(b, 6, descriptorLength-4);
 		}else if(guidance_type==1){
-			reserved2 = getInt(b, offset+3, 1, 0xFE)>>1;
-			guidance_mode = getInt(b, offset+3, 1, MASK_1BIT);
-			iso_639_language_code=getISO8859_1String(b, offset+4, 3);
-			guidance_char = new DVBString(b, offset+7, descriptorLength-5);
+			reserved2 = getInt(b, 3, 1, 0xFE)>>1;
+			guidance_mode = getInt(b, 3, 1, MASK_1BIT);
+			iso_639_language_code=getISO8859_1String(b, 4, 3);
+			guidance_char = new DVBString(b, 7, descriptorLength-5);
 		}else{
-			reserved_for_future_use = getBytes(b, offset+3, descriptorLength-3);
+			reserved_for_future_use = getBytes(b, 3, descriptorLength-3);
 		}
 
 	}
 
 	@Override
-	public DefaultMutableTreeNode getJTreeNode(final int modus){
+	public DefaultMutableTreeNode getJTreeNode(int modus) {
 
-		final DefaultMutableTreeNode t = super.getJTreeNode(modus);
-		t.add(new DefaultMutableTreeNode(new KVP("reserved",reserved,null)));
-		t.add(new DefaultMutableTreeNode(new KVP("guidance_type",guidance_type,null)));
-		if(guidance_type==0){
-			t.add(new DefaultMutableTreeNode(new KVP("ISO_639_language_code",iso_639_language_code,null)));
-			t.add(new DefaultMutableTreeNode(new KVP("guidance_char",guidance_char,null)));
-		}else if(guidance_type==1){
-			t.add(new DefaultMutableTreeNode(new KVP("reserved",reserved2,null)));
-			t.add(new DefaultMutableTreeNode(new KVP("guidance_mode",guidance_mode,(guidance_mode==1)?"guidance for content unsuitable for broadcast until after the watershed is appropriate.":null)));
-			t.add(new DefaultMutableTreeNode(new KVP("ISO_639_language_code",iso_639_language_code,null)));
-			t.add(new DefaultMutableTreeNode(new KVP("guidance_char",guidance_char,null)));
-		}else{
-			t.add(new DefaultMutableTreeNode(new KVP("reserved_for_future_use",reserved_for_future_use,null)));
+		DefaultMutableTreeNode t = super.getJTreeNode(modus);
+		t.add(new KVP("reserved", reserved));
+		t.add(new KVP("guidance_type", guidance_type));
+		if (guidance_type == 0) {
+			t.add(new KVP("ISO_639_language_code", iso_639_language_code));
+			t.add(new KVP("guidance_char", guidance_char));
+		} else if (guidance_type == 1) {
+			t.add(new KVP("reserved", reserved2));
+			t.add(new KVP("guidance_mode", guidance_mode)
+					.setDescription((guidance_mode == 1) ? "guidance for content unsuitable for broadcast until after the watershed is appropriate." : null));
+			t.add(new KVP("ISO_639_language_code", iso_639_language_code));
+			t.add(new KVP("guidance_char", guidance_char));
+		} else {
+			t.add(new KVP("reserved_for_future_use", reserved_for_future_use));
 		}
 
 		return t;

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/privatedescriptors/m7fastscan/M7OperatorNameDescriptor.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/privatedescriptors/m7fastscan/M7OperatorNameDescriptor.java
@@ -38,13 +38,13 @@ public class M7OperatorNameDescriptor extends M7Descriptor {
 	
 	public M7OperatorNameDescriptor(byte[] b, int offset, TableSection parent) {
 		super(b, offset, parent);
-		operatorName = new DVBString(b,offset+1);
+		operatorName = new DVBString(b,1);
 	}
 
 	@Override
 	public DefaultMutableTreeNode getJTreeNode(final int modus){
 		final DefaultMutableTreeNode t = super.getJTreeNode(modus);
-		t.add(new DefaultMutableTreeNode(new KVP("operator_name",operatorName ,null)));
+		t.add(new KVP("operator_name",operatorName));
 		return t;
 	}
 

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/privatedescriptors/m7fastscan/M7OperatorSublistNameDescriptor.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/privatedescriptors/m7fastscan/M7OperatorSublistNameDescriptor.java
@@ -38,13 +38,13 @@ public class M7OperatorSublistNameDescriptor extends M7Descriptor {
 	
 	public M7OperatorSublistNameDescriptor(byte[] b, int offset, TableSection parent) {
 		super(b, offset, parent);
-		operatorSublistName = new DVBString(b,offset+1);
+		operatorSublistName = new DVBString(b,1);
 	}
 
 	@Override
-	public DefaultMutableTreeNode getJTreeNode(final int modus){
+	public DefaultMutableTreeNode getJTreeNode(final int modus) {
 		final DefaultMutableTreeNode t = super.getJTreeNode(modus);
-		t.add(new DefaultMutableTreeNode(new KVP("operator_sublist_name",operatorSublistName ,null)));
+		t.add(new KVP("operator_sublist_name", operatorSublistName));
 		return t;
 	}
 

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/untable/MessageDescriptor.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/untable/MessageDescriptor.java
@@ -49,26 +49,25 @@ public class MessageDescriptor extends UNTDescriptor {
 
 	/**
 	 * @param b
-	 * @param offset
 	 * @param parent
 	 */
-	public MessageDescriptor(final byte[] b, final int offset, final TableSection parent) {
-		super(b, offset, parent);
+	public MessageDescriptor(byte[] b, TableSection parent) {
+		super(b, 0, parent);
 
-		descriptorNumber = Utils.getInt(b, offset + 2, 1, 0xF0)>>4;
-		lastDescriptorNumber = Utils.getInt(b, offset + 2, 1, Utils.MASK_4BITS);
-		iso639LanguageCode = getISO8859_1String(b, offset + 3, 3);
-		text = new DVBString(b, offset + 6, descriptorLength - 4);
+		descriptorNumber = Utils.getInt(b, 2, 1, 0xF0)>>4;
+		lastDescriptorNumber = Utils.getInt(b,2, 1, Utils.MASK_4BITS);
+		iso639LanguageCode = getISO8859_1String(b,  3, 3);
+		text = new DVBString(b, 6, descriptorLength - 4);
 
 	}
 
 	@Override
-	public DefaultMutableTreeNode getJTreeNode(final int modus) {
-		final DefaultMutableTreeNode t = super.getJTreeNode(modus);
-		t.add(new DefaultMutableTreeNode(new KVP("descriptor_number", descriptorNumber, null)));
-		t.add(new DefaultMutableTreeNode(new KVP("last_descriptor_number", lastDescriptorNumber, null)));
-		t.add(new DefaultMutableTreeNode(new KVP("ISO_639_language_code", iso639LanguageCode, null)));
-		t.add(new DefaultMutableTreeNode(new KVP("platform name", text, null)));
+	public DefaultMutableTreeNode getJTreeNode(int modus) {
+		DefaultMutableTreeNode t = super.getJTreeNode(modus);
+		t.add(new KVP("descriptor_number", descriptorNumber));
+		t.add(new KVP("last_descriptor_number", lastDescriptorNumber));
+		t.add(new KVP("ISO_639_language_code", iso639LanguageCode));
+		t.add(new KVP("platform name", text));
 		return t;
 	}
 

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/untable/SSUEventNameDescriptor.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/untable/SSUEventNameDescriptor.java
@@ -48,37 +48,27 @@ public class SSUEventNameDescriptor extends UNTDescriptor {
 
 	private final DVBString name;
 
-	private final int textLength;
-
 	private final DVBString text;
 
-	/**
-	 * @param b
-	 * @param offset
-	 * @param parent
-	 */
-	public SSUEventNameDescriptor(final byte[] b, final int offset, final TableSection parent) {
+	public SSUEventNameDescriptor(byte[] b, int offset, TableSection parent) {
 		super(b, offset, parent);
-		iso639LanguageCode = getISO8859_1String(b, offset + 2, 3);
-		nameLength = getInt(b, offset + 5, 1, MASK_8BITS);
-		// TS 102 006 V1.4.1 does not explicitly say this field uses coding as described in ETSI EN 300 468 [4], annex A. 
-		name = new DVBString(b, offset + 5);
-
-		textLength = getInt(b, offset + 6+nameLength, 1, MASK_8BITS);
-		text = new DVBString(b, offset + 6+nameLength);
+		iso639LanguageCode = getISO8859_1String(b, 2, 3);
+		nameLength = getInt(b, 5, 1, MASK_8BITS);
+		// TS 102 006 V1.4.1 does not explicitly say this field uses coding as described
+		// in ETSI EN 300 468 [4], annex A.
+		name = new DVBString(b, 5);
+		text = new DVBString(b, 6 + nameLength);
 
 	}
 
 	@Override
-	public DefaultMutableTreeNode getJTreeNode(final int modus) {
-		final DefaultMutableTreeNode t = super.getJTreeNode(modus);
-		t.add(new DefaultMutableTreeNode(new KVP("ISO_639_language_code", iso639LanguageCode, null)));
-		t.add(new DefaultMutableTreeNode(new KVP("name_length", nameLength, null)));
-		t.add(new DefaultMutableTreeNode(new KVP("name", name, null)));
-		t.add(new DefaultMutableTreeNode(new KVP("text_length", textLength, null)));
-		t.add(new DefaultMutableTreeNode(new KVP("text", text, null)));
+	public DefaultMutableTreeNode getJTreeNode(int modus) {
+		DefaultMutableTreeNode t = super.getJTreeNode(modus);
+		t.add(new KVP("ISO_639_language_code", iso639LanguageCode));
+		t.add(new KVP("name_length", nameLength));
+		t.add(new KVP("name", name));
+		t.add(new KVP("text", text));
 		return t;
 	}
-
 
 }

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/audio/Audio138183Handler.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/audio/Audio138183Handler.java
@@ -123,7 +123,7 @@ public class Audio138183Handler extends GeneralPesHandler implements ImageSource
 	}
 
 	private byte[] rdsData=new byte[0];
-	private final List<AudioAccessUnit> audioAccessUnits = new ArrayList<AudioAccessUnit>();
+	private final List<AudioAccessUnit> audioAccessUnits = new ArrayList<>();
 
 	private SwingPlayer swPlayer = null;
 	private KVP kvp = null;
@@ -150,7 +150,7 @@ public class Audio138183Handler extends GeneralPesHandler implements ImageSource
 
 		copyIntoBuf(audioPes);
 
-		final List<AudioAccessUnit> accessUnits = new ArrayList<AudioAccessUnit>();
+		final List<AudioAccessUnit> accessUnits = new ArrayList<>();
 		int i = bufStart;
 
 		while ((i < (bufEnd)) && (i >= 0)) {
@@ -209,7 +209,7 @@ public class Audio138183Handler extends GeneralPesHandler implements ImageSource
 	@Override
 	public DefaultMutableTreeNode getJTreeNode(final int modus) {
 
-		kvp = new KVP("PES Data",this);
+		kvp = new KVP("PES Data").addImageSource(this, "audio");
 		if(swPlayer==null){
 			JMenuItem objectMenu = new JMenuItem("Play Audio");
 			objectMenu.setActionCommand(DVBtree.PLAY);

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/dvbsubtitling/CLUTDefinitionSegment.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/dvbsubtitling/CLUTDefinitionSegment.java
@@ -42,21 +42,21 @@ import nl.digitalekabeltelevisie.util.Utils;
 
 public class CLUTDefinitionSegment extends Segment{
 
-	private int CLUT_2bit[];
-	private int CLUT_4bit[];
-	private int CLUT_8bit[];
+	private int[] CLUT_2bit;
+	private int[] CLUT_4bit;
+	private int[] CLUT_8bit;
 
-	private static final int default_CLUT_2bit[] = {
+	private static final int[] default_CLUT_2bit = {
 		0, 0xFFFFFFFF, 0xFF000000, 0xFF808080
 	};
 
-	private static final int default_CLUT_4bit[] = {
+	private static final int[] default_CLUT_4bit = {
 		0, 0xFFFF0000, 0xFF00FF00, 0xFFFFFF00, 0xFF0000FF, 0xFFFF00FF,
 		0xFF00FFFF, 0xFFFFFFFF, 0xFF000000, 0xFF800000, 0xFF008000,
 		0xFF808000, 0xFF000080, 0xFF800080, 0xFF008080, 0xFF808080
 	};
 
-	private static final int	default_CLUT_8bit[]	= { 0x0, 0x40ff0000, 0x4000ff00, 0x40ffff00, 0x400000ff,
+	private static final int[] default_CLUT_8bit = { 0x0, 0x40ff0000, 0x4000ff00, 0x40ffff00, 0x400000ff,
 		0x40ff00ff, 0x4000ffff, 0x40ffffff, 0x80000000, 0x80550000, 0x80005500, 0x80555500, 0x80000055, 0x80550055,
 		0x80005555, 0x80555555, 0xffaa0000, 0xffff0000, 0xffaa5500, 0xffff5500, 0xffaa0055, 0xffff0055, 0xffaa5555,
 		0xffff5555, 0x80aa0000, 0x80ff0000, 0x80aa5500, 0x80ff5500, 0x80aa0055, 0x80ff0055, 0x80aa5555, 0x80ff5555,
@@ -108,10 +108,10 @@ public class CLUTDefinitionSegment extends Segment{
 
 		private final int t_value;
 
-		public CLUTEntry(final int clut_entry_id, final int clut_flag_2_bit_entry,
-				final int clut_flag_4_bit_entry, final int clut_flag_8_bit_entry,
-				final int full_range_flag, final int y_value, final int cr_value, final int cb_value,
-				final int t_value) {
+		public CLUTEntry(int clut_entry_id, int clut_flag_2_bit_entry,
+                         int clut_flag_4_bit_entry, int clut_flag_8_bit_entry,
+                         int full_range_flag, int y_value, int cr_value, int cb_value,
+                         int t_value) {
 			CLUT_entry_id = clut_entry_id;
 			CLUT_flag_2_bit_entry = clut_flag_2_bit_entry;
 			CLUT_flag_4_bit_entry = clut_flag_4_bit_entry;
@@ -124,7 +124,7 @@ public class CLUTDefinitionSegment extends Segment{
 		}
 
 		@Override
-		public KVP getJTreeNode(final int modus) {
+		public KVP getJTreeNode(int modus) {
 			int r, g, b;
 			float y, cr, cb;
 			if (full_range_flag == 1) {
@@ -159,10 +159,10 @@ public class CLUTDefinitionSegment extends Segment{
 			//			g = (int) ((y - 16) * 1.164 - (0.813 * (cr - 128)) - 0.391 * (cb - 128));
 			//			b = (int) ((y - 16) * 1.164 + (2.018 * (cb - 128)));
 
-			final String bgColor = "#" + Utils.toHexStringUnformatted(r, 2)
-					+ Utils.toHexStringUnformatted(g, 2)
-					+ Utils.toHexStringUnformatted(b, 2);
-			final KVP s = new KVP("CLUT_entry id "+ CLUT_entry_id).setHtmlLabel("CLUT_entry <code><span style=\"background-color: "+ bgColor
+			String bgColor = "#" + toHexStringUnformatted(r, 2)
+					+ toHexStringUnformatted(g, 2)
+					+ toHexStringUnformatted(b, 2);
+			KVP s = new KVP("CLUT_entry id "+ CLUT_entry_id).setHtmlLabel("CLUT_entry <code><span style=\"background-color: "+ bgColor
 					+ "; color: white;\">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span></code>");
 			s.add(new KVP("CLUT_entry_id", CLUT_entry_id));
 			s.add(new KVP("2-bit/entry_CLUT_flag", CLUT_flag_2_bit_entry));
@@ -177,8 +177,8 @@ public class CLUTDefinitionSegment extends Segment{
 		}
 
 
-		private static int boundRange(final int r) {
-			return r < 0 ? 0 : (r > 0xFF ? 0xFF : r);
+		private static int boundRange(int r) {
+			return (Math.clamp(r, 0, 0xFF));
 		}
 
 
@@ -262,9 +262,9 @@ public class CLUTDefinitionSegment extends Segment{
 		}
 	}
 
-	public CLUTDefinitionSegment(final byte[] data, final int offset) {
+	public CLUTDefinitionSegment(byte[] data, int offset) {
 		super(data, offset);
-		for(final CLUTEntry clutEntry : getCLUTEntries()){
+		for(CLUTEntry clutEntry : getCLUTEntries()){
 			if(clutEntry.getCLUT_flag_2_bit_entry()==1){
 				if(CLUT_2bit==null){
 					CLUT_2bit=Arrays.copyOf(default_CLUT_2bit, default_CLUT_2bit.length);
@@ -293,8 +293,8 @@ public class CLUTDefinitionSegment extends Segment{
 	}
 
 	@Override
-	public KVP getJTreeNode(final int modus) {
-		final KVP s = super.getJTreeNode(modus);
+	public KVP getJTreeNode(int modus) {
+		KVP s = super.getJTreeNode(modus);
 		s.add(new KVP("CLUT-id", getCLUTId()));
 		s.add(new KVP("CLUT_version_number",	getCLUTVersionNumber()));
 		addListJTree(s, getCLUTEntries(), modus, "CLUTEntries");
@@ -313,16 +313,16 @@ public class CLUTDefinitionSegment extends Segment{
 	}
 
 
-	public final List<CLUTEntry> getCLUTEntries() {
-		final List<CLUTEntry> clutEntries = new ArrayList<>();
+	public List<CLUTEntry> getCLUTEntries() {
+		List<CLUTEntry> clutEntries = new ArrayList<>();
 		int t = 0;
 		while ((t + 2) < getSegmentLength()) {
-			final int CLUT_entry_id = getInt(data_block, offset + 8 + t, 1,
+			int CLUT_entry_id = getInt(data_block, offset + 8 + t, 1,
 					MASK_8BITS);
-			final int flag_2bit = getInt(data_block, offset + 9 + t, 1, 0x80) >> 7;
-			final int flag_4bit = getInt(data_block, offset + 9 + t, 1, 0x40) >> 6;
-			final int flag_8bit = getInt(data_block, offset + 9 + t, 1, 0x20) >> 5;
-			final int full_range_flag = getInt(data_block, offset + 9 + t, 1, 0x01);
+			int flag_2bit = getInt(data_block, offset + 9 + t, 1, 0x80) >> 7;
+			int flag_4bit = getInt(data_block, offset + 9 + t, 1, 0x40) >> 6;
+			int flag_8bit = getInt(data_block, offset + 9 + t, 1, 0x20) >> 5;
+			int full_range_flag = getInt(data_block, offset + 9 + t, 1, 0x01);
 			int y_value, cr_value, cb_value, t_value;
 			if (full_range_flag == 1) {
 				y_value = getInt(data_block, offset + 10 + t, 1, MASK_8BITS);
@@ -357,7 +357,7 @@ public class CLUTDefinitionSegment extends Segment{
 		return getIndexColorModel(8,256,default_CLUT_8bit, 0,true,0,DataBuffer.TYPE_BYTE);
 	}
 
-	public static IndexColorModel getDefaultColorModel(final int regionDepth){
+	public static IndexColorModel getDefaultColorModel(int regionDepth){
 		return switch (regionDepth) {
 		case 1 -> getDefault_CLUT_2bitColorModel();
 		case 2 -> getDefault_CLUT_4bitColorModel();
@@ -367,7 +367,7 @@ public class CLUTDefinitionSegment extends Segment{
 	}
 
 
-	public IndexColorModel getColorModel(final int regionDepth){
+	public IndexColorModel getColorModel(int regionDepth){
 
 		switch (regionDepth) {
 		case 1: // 2 bit
@@ -406,17 +406,17 @@ public class CLUTDefinitionSegment extends Segment{
 	 * @param transferType
 	 * @return
 	 */
-	private static IndexColorModel getIndexColorModel(final int bits, final int size, final int cmap[], final int start, final boolean hasalpha, final int trans, final int transferType) {
-		final byte[] r =new byte[cmap.length];
-		final byte[] g =new byte[cmap.length];
-		final byte[] b =new byte[cmap.length];
-		final byte[] a =new byte[cmap.length];
+	private static IndexColorModel getIndexColorModel(int bits, int size, int[] cmap, int start, boolean hasalpha, int trans, int transferType) {
+		byte[] r =new byte[cmap.length];
+		byte[] g =new byte[cmap.length];
+		byte[] b =new byte[cmap.length];
+		byte[] a =new byte[cmap.length];
 
 		for (int i = 0; i < cmap.length; i++) {
-			r[i] = Utils.getInt2UnsignedByte((cmap[i]& 0xFF0000)>>16);
-			g[i] = Utils.getInt2UnsignedByte((cmap[i]& 0x00FF00)>>8);
-			b[i] = Utils.getInt2UnsignedByte((cmap[i]& 0x0000FF));
-			a[i] = Utils.getInt2UnsignedByte((cmap[i]& 0xFF000000)>>>24);
+			r[i] = getInt2UnsignedByte((cmap[i]& 0xFF0000)>>16);
+			g[i] = getInt2UnsignedByte((cmap[i]& 0x00FF00)>>8);
+			b[i] = getInt2UnsignedByte((cmap[i]& 0x0000FF));
+			a[i] = getInt2UnsignedByte((cmap[i]& 0xFF000000)>>>24);
 		}
 		return new IndexColorModel(bits,size,r,g,b,a);
 	}

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/dvbsubtitling/CLUTDefinitionSegment.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/dvbsubtitling/CLUTDefinitionSegment.java
@@ -2,7 +2,7 @@
  *
  *  http://www.digitalekabeltelevisie.nl/dvb_inspector
  *
- *  This code is Copyright 2009-2012 by Eric Berendsen (e_berendsen@digitalekabeltelevisie.nl)
+ *  This code is Copyright 2009-2024 by Eric Berendsen (e_berendsen@digitalekabeltelevisie.nl)
  *
  *  This file is part of DVB Inspector.
  *
@@ -35,13 +35,12 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import javax.swing.tree.DefaultMutableTreeNode;
 
 import nl.digitalekabeltelevisie.controller.KVP;
 import nl.digitalekabeltelevisie.controller.TreeNode;
 import nl.digitalekabeltelevisie.util.Utils;
 
-public class CLUTDefinitionSegment extends Segment implements TreeNode {
+public class CLUTDefinitionSegment extends Segment{
 
 	private int CLUT_2bit[];
 	private int CLUT_4bit[];
@@ -113,7 +112,6 @@ public class CLUTDefinitionSegment extends Segment implements TreeNode {
 				final int clut_flag_4_bit_entry, final int clut_flag_8_bit_entry,
 				final int full_range_flag, final int y_value, final int cr_value, final int cb_value,
 				final int t_value) {
-			super();
 			CLUT_entry_id = clut_entry_id;
 			CLUT_flag_2_bit_entry = clut_flag_2_bit_entry;
 			CLUT_flag_4_bit_entry = clut_flag_4_bit_entry;
@@ -125,7 +123,8 @@ public class CLUTDefinitionSegment extends Segment implements TreeNode {
 			this.t_value = t_value;
 		}
 
-		public DefaultMutableTreeNode getJTreeNode(final int modus) {
+		@Override
+		public KVP getJTreeNode(final int modus) {
 			int r, g, b;
 			float y, cr, cb;
 			if (full_range_flag == 1) {
@@ -163,107 +162,66 @@ public class CLUTDefinitionSegment extends Segment implements TreeNode {
 			final String bgColor = "#" + Utils.toHexStringUnformatted(r, 2)
 					+ Utils.toHexStringUnformatted(g, 2)
 					+ Utils.toHexStringUnformatted(b, 2);
-			final DefaultMutableTreeNode s = new DefaultMutableTreeNode(new KVP("CLUT_entry id "+ CLUT_entry_id).setHtmlLabel("CLUT_entry <code><span style=\"background-color: "+ bgColor
-					+ "; color: white;\">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span></code>"));  
-			s.add(new DefaultMutableTreeNode(new KVP("CLUT_entry_id",
-					CLUT_entry_id, null)));
-			s.add(new DefaultMutableTreeNode(new KVP("2-bit/entry_CLUT_flag",
-					CLUT_flag_2_bit_entry, null)));
-			s.add(new DefaultMutableTreeNode(new KVP("4-bit/entry_CLUT_flag",
-					CLUT_flag_4_bit_entry, null)));
-			s.add(new DefaultMutableTreeNode(new KVP("8-bit/entry_CLUT_flag",
-					CLUT_flag_8_bit_entry, null)));
-			s.add(new DefaultMutableTreeNode(new KVP("full_range_flag",
-					full_range_flag, null)));
-			s
-			.add(new DefaultMutableTreeNode(new KVP("Y-value", y_value,
-					null)));
-			s.add(new DefaultMutableTreeNode(
-					new KVP("Cr-value", cr_value, null)));
-			s.add(new DefaultMutableTreeNode(
-					new KVP("Cb-value", cb_value, null)));
-			s
-			.add(new DefaultMutableTreeNode(new KVP("T-value", t_value,
-					null)));
+			final KVP s = new KVP("CLUT_entry id "+ CLUT_entry_id).setHtmlLabel("CLUT_entry <code><span style=\"background-color: "+ bgColor
+					+ "; color: white;\">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span></code>");
+			s.add(new KVP("CLUT_entry_id", CLUT_entry_id));
+			s.add(new KVP("2-bit/entry_CLUT_flag", CLUT_flag_2_bit_entry));
+			s.add(new KVP("4-bit/entry_CLUT_flag", CLUT_flag_4_bit_entry));
+			s.add(new KVP("8-bit/entry_CLUT_flag", CLUT_flag_8_bit_entry));
+			s.add(new KVP("full_range_flag", full_range_flag));
+			s.add(new KVP("Y-value", y_value, null));
+			s.add(new KVP("Cr-value", cr_value));
+			s.add(new KVP("Cb-value", cb_value));
+			s.add(new KVP("T-value", t_value));
 			return s;
 		}
 
-		/**
-		 * @param r
-		 * @return
-		 */
+
 		private static int boundRange(final int r) {
 			return r < 0 ? 0 : (r > 0xFF ? 0xFF : r);
 		}
 
 
-		/**
-		 * @return the cb_value
-		 */
 		public int getCb_value() {
 			return cb_value;
 		}
 
 
-		/**
-		 * @return the cLUT_entry_id
-		 */
 		public int getCLUT_entry_id() {
 			return CLUT_entry_id;
 		}
 
 
-		/**
-		 * @return the cLUT_flag_2_bit_entry
-		 */
 		public int getCLUT_flag_2_bit_entry() {
 			return CLUT_flag_2_bit_entry;
 		}
 
 
-		/**
-		 * @return the cLUT_flag_4_bit_entry
-		 */
 		public int getCLUT_flag_4_bit_entry() {
 			return CLUT_flag_4_bit_entry;
 		}
 
 
-		/**
-		 * @return the cLUT_flag_8_bit_entry
-		 */
 		public int getCLUT_flag_8_bit_entry() {
 			return CLUT_flag_8_bit_entry;
 		}
 
 
-		/**
-		 * @return the cr_value
-		 */
 		public int getCr_value() {
 			return cr_value;
 		}
 
 
-		/**
-		 * @return the full_range_flag
-		 */
 		public int getFull_range_flag() {
 			return full_range_flag;
 		}
 
 
-		/**
-		 * @return the t_value
-		 */
 		public int getT_value() {
 			return t_value;
 		}
 
 
-		/**
-		 * @return the y_value
-		 */
 		public int getY_value() {
 			return y_value;
 		}
@@ -337,30 +295,24 @@ public class CLUTDefinitionSegment extends Segment implements TreeNode {
 	@Override
 	public KVP getJTreeNode(final int modus) {
 		final KVP s = super.getJTreeNode(modus);
-		s.add(new DefaultMutableTreeNode(new KVP("CLUT-id", getCLUTId(),null)));
-		s.add(new DefaultMutableTreeNode(new KVP("CLUT_version_number",	getCLUTVersionNumber(), null)));
+		s.add(new KVP("CLUT-id", getCLUTId()));
+		s.add(new KVP("CLUT_version_number",	getCLUTVersionNumber()));
 		addListJTree(s, getCLUTEntries(), modus, "CLUTEntries");
 
 		return s;
 	}
 
-	/**
-	 * @return
-	 */
+
 	public int getCLUTVersionNumber() {
 		return getInt(data_block, offset + 7, 1, 0xF0) >> 4;
 	}
 
-	/**
-	 * @return
-	 */
+
 	public int getCLUTId() {
 		return getInt(data_block, offset + 6, 1, MASK_8BITS);
 	}
 
-	/**
-	 * @return
-	 */
+
 	public final List<CLUTEntry> getCLUTEntries() {
 		final List<CLUTEntry> clutEntries = new ArrayList<>();
 		int t = 0;
@@ -406,17 +358,12 @@ public class CLUTDefinitionSegment extends Segment implements TreeNode {
 	}
 
 	public static IndexColorModel getDefaultColorModel(final int regionDepth){
-
-		switch (regionDepth) {
-		case 1: // 2 bit
-			return getDefault_CLUT_2bitColorModel();
-		case 2: // 4 bit
-			return getDefault_CLUT_4bitColorModel();
-		case 3:
-			return getDefault_CLUT_8bitColorModel();
-		default:
-			return null;
-		}
+		return switch (regionDepth) {
+		case 1 -> getDefault_CLUT_2bitColorModel();
+		case 2 -> getDefault_CLUT_4bitColorModel();
+		case 3 -> getDefault_CLUT_8bitColorModel();
+		default -> null;
+		};
 	}
 
 

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/dvbsubtitling/CLUTDefinitionSegment.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/dvbsubtitling/CLUTDefinitionSegment.java
@@ -163,9 +163,8 @@ public class CLUTDefinitionSegment extends Segment implements TreeNode {
 			final String bgColor = "#" + Utils.toHexStringUnformatted(r, 2)
 					+ Utils.toHexStringUnformatted(g, 2)
 					+ Utils.toHexStringUnformatted(b, 2);
-			final DefaultMutableTreeNode s = new DefaultMutableTreeNode(new KVP("CLUT_entry <code><span style=\"background-color: "+ bgColor
-					+ "; color: white;\">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span></code>",
-					"CLUT_entry id "+ CLUT_entry_id));  // plain text alternative
+			final DefaultMutableTreeNode s = new DefaultMutableTreeNode(new KVP("CLUT_entry id "+ CLUT_entry_id).setHtmlLabel("CLUT_entry <code><span style=\"background-color: "+ bgColor
+					+ "; color: white;\">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span></code>"));  
 			s.add(new DefaultMutableTreeNode(new KVP("CLUT_entry_id",
 					CLUT_entry_id, null)));
 			s.add(new DefaultMutableTreeNode(new KVP("2-bit/entry_CLUT_flag",
@@ -336,8 +335,8 @@ public class CLUTDefinitionSegment extends Segment implements TreeNode {
 	}
 
 	@Override
-	public DefaultMutableTreeNode getJTreeNode(final int modus) {
-		final DefaultMutableTreeNode s = super.getJTreeNode(modus);
+	public KVP getJTreeNode(final int modus) {
+		final KVP s = super.getJTreeNode(modus);
 		s.add(new DefaultMutableTreeNode(new KVP("CLUT-id", getCLUTId(),null)));
 		s.add(new DefaultMutableTreeNode(new KVP("CLUT_version_number",	getCLUTVersionNumber(), null)));
 		addListJTree(s, getCLUTEntries(), modus, "CLUTEntries");
@@ -363,7 +362,7 @@ public class CLUTDefinitionSegment extends Segment implements TreeNode {
 	 * @return
 	 */
 	public final List<CLUTEntry> getCLUTEntries() {
-		final ArrayList<CLUTEntry> clutEntries = new ArrayList<CLUTEntry>();
+		final List<CLUTEntry> clutEntries = new ArrayList<>();
 		int t = 0;
 		while ((t + 2) < getSegmentLength()) {
 			final int CLUT_entry_id = getInt(data_block, offset + 8 + t, 1,
@@ -427,21 +426,18 @@ public class CLUTDefinitionSegment extends Segment implements TreeNode {
 		case 1: // 2 bit
 			if(CLUT_2bit==null){
 				return getDefault_CLUT_2bitColorModel();
-			}else{
-				return getIndexColorModel(2,4,CLUT_2bit, 0,true,-1,DataBuffer.TYPE_BYTE);
 			}
+			return getIndexColorModel(2,4,CLUT_2bit, 0,true,-1,DataBuffer.TYPE_BYTE);
 		case 2: // 4 bit
 			if(CLUT_4bit==null){
 				return getDefault_CLUT_4bitColorModel();
-			}else{
-				return getIndexColorModel(4,16,CLUT_4bit,0,true,-1,DataBuffer.TYPE_BYTE);
 			}
+			return getIndexColorModel(4,16,CLUT_4bit,0,true,-1,DataBuffer.TYPE_BYTE);
 		case 3:
 			if(CLUT_8bit==null){
 				return getDefault_CLUT_8bitColorModel();
-			}else{
-				return getIndexColorModel(8,256,CLUT_8bit, 0,true,-1,DataBuffer.TYPE_BYTE);
 			}
+			return getIndexColorModel(8,256,CLUT_8bit, 0,true,-1,DataBuffer.TYPE_BYTE);
 		default:
 			return null;
 		}

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/dvbsubtitling/DVBSubtitleHandler.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/dvbsubtitling/DVBSubtitleHandler.java
@@ -42,8 +42,8 @@ public class DVBSubtitleHandler extends GeneralPesHandler{
 
 
 	@Override
-	protected void processPesDataBytes(final PesPacketData pesData) {
-		final DVBSubtitlingPESDataField titlePesPacket = new DVBSubtitlingPESDataField(pesData);
+	protected void processPesDataBytes(PesPacketData pesData) {
+		DVBSubtitlingPESDataField titlePesPacket = new DVBSubtitlingPESDataField(pesData);
 		pesPackets.add(titlePesPacket);
 		if((titlePesPacket.getPesStreamID()==0xBD)// "private_stream_1". 
 				&&(titlePesPacket.getData_identifier()==0x20) // For DVB subtitle streams the data_identifier field shall be coded with the value 0x20.
@@ -63,8 +63,8 @@ public class DVBSubtitleHandler extends GeneralPesHandler{
 	 * @see nl.digitalekabeltelevisie.controller.TreeNode#getJTreeNode(int)
 	 */
 	@Override
-	public DefaultMutableTreeNode getJTreeNode(final int modus) {
-		final DefaultMutableTreeNode s=super.getJTreeNode(modus);
+	public DefaultMutableTreeNode getJTreeNode(int modus) {
+		DefaultMutableTreeNode s=super.getJTreeNode(modus);
 
 		if(titles!=null){
 			s.add(titles.getJTreeNode(modus));

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/dvbsubtitling/DVBSubtitlingPESDataField.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/dvbsubtitling/DVBSubtitlingPESDataField.java
@@ -76,13 +76,13 @@ public class DVBSubtitlingPESDataField extends PesPacketData implements ImageSou
 
 
 	static {
-		try {
-			InputStream fileInputStream = classLoader.getResourceAsStream("monitors576.jpg");
-			bgImage576 = ImageIO.read(fileInputStream);
-			fileInputStream = classLoader.getResourceAsStream("monitors720.jpg");
-			bgImage720 = ImageIO.read(fileInputStream);
-			fileInputStream = classLoader.getResourceAsStream("monitors1080.jpg");
-			bgImage1080 = ImageIO.read(fileInputStream);
+		try (InputStream fileInputStream576 = classLoader.getResourceAsStream("monitors576.jpg");
+				InputStream fileInputStream720 = classLoader.getResourceAsStream("monitors720.jpg");
+				InputStream fileInputStream1080 = classLoader.getResourceAsStream("monitors1080.jpg");
+				){
+			bgImage576 = ImageIO.read(fileInputStream576);
+			bgImage720 = ImageIO.read(fileInputStream720);
+			bgImage1080 = ImageIO.read(fileInputStream1080);
 		} catch (Exception e) {
 			logger.log(Level.WARNING, "error reading image ", e);
 		}

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/dvbsubtitling/DVBSubtitlingPESDataField.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/dvbsubtitling/DVBSubtitlingPESDataField.java
@@ -161,7 +161,7 @@ public class DVBSubtitlingPESDataField extends PesPacketData implements TreeNode
 	@Override
 	public DefaultMutableTreeNode getJTreeNode(final int modus) {
 
-		final DefaultMutableTreeNode s = super.getJTreeNode(modus,new KVP("DVBSubtitlingSegments",this));
+		final DefaultMutableTreeNode s = super.getJTreeNode(modus,new KVP("DVBSubtitlingSegments").addImageSource(this, "DVBSubtitlingSegments"));
 		if(pesDataLen>0) { // PES packet with more than just header
 			s.add(new DefaultMutableTreeNode(new KVP("data_identifier",data_identifier, getDataIDString(data_identifier))));
 			if(data_identifier==0x20){ // For DVB subtitle streams the data_identifier field shall be coded with the value 0x20. 300 743 V1.3.1 p.20

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/dvbsubtitling/DVBSubtitlingPESDataField.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/dvbsubtitling/DVBSubtitlingPESDataField.java
@@ -2,7 +2,7 @@
  *
  *  http://www.digitalekabeltelevisie.nl/dvb_inspector
  *
- *  This code is Copyright 2009-2020 by Eric Berendsen (e_berendsen@digitalekabeltelevisie.nl)
+ *  This code is Copyright 2009-2024 by Eric Berendsen (e_berendsen@digitalekabeltelevisie.nl)
  *
  *  This file is part of DVB Inspector.
  *
@@ -52,7 +52,7 @@ import nl.digitalekabeltelevisie.gui.ImageSource;
  *
  */
 
-public class DVBSubtitlingPESDataField extends PesPacketData implements TreeNode, ImageSource {
+public class DVBSubtitlingPESDataField extends PesPacketData implements ImageSource {
 
 	/**
 	 *
@@ -63,9 +63,9 @@ public class DVBSubtitlingPESDataField extends PesPacketData implements TreeNode
 	private int subtitle_stream_id;
 
 	private DisplayDefinitionSegment displayDefinitionSegment = null;
-	private final Map<Integer, RegionCompositionSegment> regionCompositionsSegments = new HashMap<Integer, RegionCompositionSegment>();
-	private final Map<Integer, CLUTDefinitionSegment> clutDefinitions= new HashMap<Integer, CLUTDefinitionSegment>();
-	private final Map<Integer, ObjectDataSegment> objects= new HashMap<Integer, ObjectDataSegment>();
+	private final Map<Integer, RegionCompositionSegment> regionCompositionsSegments = new HashMap<>();
+	private final Map<Integer, CLUTDefinitionSegment> clutDefinitions= new HashMap<>();
+	private final Map<Integer, ObjectDataSegment> objects= new HashMap<>();
 	public static BufferedImage bgImage576;
 	public static BufferedImage bgImage720;
 	public static BufferedImage bgImage1080;
@@ -93,7 +93,7 @@ public class DVBSubtitlingPESDataField extends PesPacketData implements TreeNode
 	/**
 	 *
 	 */
-	private final List<Segment> segmentList = new ArrayList<Segment>();
+	private final List<Segment> segmentList = new ArrayList<>();
 
 
 	/**
@@ -108,11 +108,11 @@ public class DVBSubtitlingPESDataField extends PesPacketData implements TreeNode
 
 		final int offset = getPesDataStart();
 		if(pesDataLen>0) { // PES packet with more than just header
-		data_identifier = getInt(data, offset, 1, MASK_8BITS);
+			data_identifier = getInt(data, offset, 1, MASK_8BITS);
 			if(data_identifier==0x20){ // For DVB subtitle streams the data_identifier field shall be coded with the value 0x20. 300 743 V1.3.1 p.20
 				subtitle_stream_id = getInt(data, offset + 1, 1, MASK_8BITS);
-	
-	
+
+
 				int t = 2;
 				while (data[offset + t] == 0x0f) { // sync byte
 					Segment segment;
@@ -140,12 +140,12 @@ public class DVBSubtitlingPESDataField extends PesPacketData implements TreeNode
 						segment = new DisplayDefinitionSegment(data, offset + t);
 						displayDefinitionSegment = (DisplayDefinitionSegment)segment;
 						break;
-	
+
 					default:
 						segment = new Segment(data, offset + t);
 						break;
 					}
-	
+
 					segmentList.add(segment);
 					t += 6 + getInt(data, offset + t + 4, 2, MASK_16BITS);
 				}
@@ -163,9 +163,9 @@ public class DVBSubtitlingPESDataField extends PesPacketData implements TreeNode
 
 		final DefaultMutableTreeNode s = super.getJTreeNode(modus,new KVP("DVBSubtitlingSegments").addImageSource(this, "DVBSubtitlingSegments"));
 		if(pesDataLen>0) { // PES packet with more than just header
-			s.add(new DefaultMutableTreeNode(new KVP("data_identifier",data_identifier, getDataIDString(data_identifier))));
+			s.add(new KVP("data_identifier",data_identifier).setDescription(getDataIDString(data_identifier)));
 			if(data_identifier==0x20){ // For DVB subtitle streams the data_identifier field shall be coded with the value 0x20. 300 743 V1.3.1 p.20
-				s.add(new DefaultMutableTreeNode(new KVP("subtitle_stream_id",subtitle_stream_id, null)));
+				s.add(new KVP("subtitle_stream_id",subtitle_stream_id));
 				addListJTree(s, segmentList, modus, "segments");
 			}
 		}
@@ -186,6 +186,7 @@ public class DVBSubtitlingPESDataField extends PesPacketData implements TreeNode
 	 * This is different from the getImage in DisplaySet as this draws directly on the background, not on regions.
 	 * @see nl.digitalekabeltelevisie.gui.ImageSource#getImage()
 	 */
+	@Override
 	public BufferedImage getImage() {
 		final PesHeader pesHeader = getPesHeader();
 		if((data_identifier==0x20)&& // For DVB subtitle streams the data_identifier field shall be coded with the value 0x20. 300 743 V1.3.1 p.20
@@ -311,29 +312,18 @@ public class DVBSubtitlingPESDataField extends PesPacketData implements TreeNode
 		if ((0x81 <= type) && (type <= 0xef)) {
 			return "private data";
 		}
-		switch (type) {
-
-		case 0x10:
-			return "page composition segment";
-		case 0x11:
-			return "region composition segment";
-		case 0x12:
-			return "CLUT definition segment";
-		case 0x13:
-			return "object data segment";
-		case 0x14:
-			return "display definition segment";
-		case 0x15:
-			return "disparity signalling segment";
-		case 0x16:
-			return "alternative_CLUT_segment";
-		case 0x80:
-			return "end of display set segment";
-		case 0xFF:
-			return "stuffing";
-		default:
-			return "reserved for future use";
-		}
+		return switch (type) {
+		case 0x10 -> "page composition segment";
+		case 0x11 -> "region composition segment";
+		case 0x12 -> "CLUT definition segment";
+		case 0x13 -> "object data segment";
+		case 0x14 -> "display definition segment";
+		case 0x15 -> "disparity signalling segment";
+		case 0x16 -> "alternative_CLUT_segment";
+		case 0x80 -> "end of display set segment";
+		case 0xFF -> "stuffing";
+		default -> "reserved for future use";
+		};
 	}
 
 	/**
@@ -342,19 +332,13 @@ public class DVBSubtitlingPESDataField extends PesPacketData implements TreeNode
 	 */
 	public static String getPageStateString(final int type) {
 
-		switch (type) {
-
-		case 0x0:
-			return "normal case - The display set contains only the subtitle elements that are changed from the previous page instance.";
-		case 0x1:
-			return "acquisition point - The display set contains all subtitle elements needed to display the next page instance.";
-		case 0x2:
-			return "mode change - The display set contains all subtitle elements needed to display the new page.";
-		case 0x3:
-			return "reserved";
-		default:
-			return "Illegal value";
-		}
+		return switch (type) {
+		case 0x0 -> "normal case - The display set contains only the subtitle elements that are changed from the previous page instance.";
+		case 0x1 -> "acquisition point - The display set contains all subtitle elements needed to display the next page instance.";
+		case 0x2 -> "mode change - The display set contains all subtitle elements needed to display the new page.";
+		case 0x3 -> "reserved";
+		default -> "Illegal value";
+		};
 	}
 
 }

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/dvbsubtitling/DisplayDefinitionSegment.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/dvbsubtitling/DisplayDefinitionSegment.java
@@ -35,13 +35,13 @@ import nl.digitalekabeltelevisie.controller.KVP;
 
 public class DisplayDefinitionSegment extends Segment{
 
-	public DisplayDefinitionSegment(final byte[] data,final int offset) {
+	public DisplayDefinitionSegment(byte[] data, int offset) {
 		super(data,offset);
 	}
 
 	@Override
-	public KVP getJTreeNode(final int modus) {
-		final KVP s = super.getJTreeNode(modus);
+	public KVP getJTreeNode(int modus) {
+		KVP s = super.getJTreeNode(modus);
 		s.add(new KVP("dds_version_number",getDDSVersionNumber()));
 		s.add(new KVP("display_window_flag",getDisplayWindowFlag()));
 		s.add(new KVP("display_width",getDisplayWidth()).setDescription("("+(getDisplayWidth()+1)+")"));

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/dvbsubtitling/DisplayDefinitionSegment.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/dvbsubtitling/DisplayDefinitionSegment.java
@@ -2,7 +2,7 @@
  *
  *  http://www.digitalekabeltelevisie.nl/dvb_inspector
  *
- *  This code is Copyright 2009-2012 by Eric Berendsen (e_berendsen@digitalekabeltelevisie.nl)
+ *  This code is Copyright 2009-2024 by Eric Berendsen (e_berendsen@digitalekabeltelevisie.nl)
  *
  *  This file is part of DVB Inspector.
  *
@@ -29,12 +29,11 @@ package nl.digitalekabeltelevisie.data.mpeg.pes.dvbsubtitling;
 
 import static nl.digitalekabeltelevisie.util.Utils.*;
 
-import javax.swing.tree.DefaultMutableTreeNode;
 
 import nl.digitalekabeltelevisie.controller.KVP;
-import nl.digitalekabeltelevisie.controller.TreeNode;
 
-public class DisplayDefinitionSegment extends Segment implements TreeNode{
+
+public class DisplayDefinitionSegment extends Segment{
 
 	public DisplayDefinitionSegment(final byte[] data,final int offset) {
 		super(data,offset);
@@ -43,15 +42,15 @@ public class DisplayDefinitionSegment extends Segment implements TreeNode{
 	@Override
 	public KVP getJTreeNode(final int modus) {
 		final KVP s = super.getJTreeNode(modus);
-		s.add(new DefaultMutableTreeNode(new KVP("dds_version_number",getDDSVersionNumber(),null)));
-		s.add(new DefaultMutableTreeNode(new KVP("display_window_flag",getDisplayWindowFlag(),null)));
-		s.add(new DefaultMutableTreeNode(new KVP("display_width",getDisplayWidth(),"("+(getDisplayWidth()+1)+")")));
-		s.add(new DefaultMutableTreeNode(new KVP("display_height",getDisplayHeight(),"("+(getDisplayHeight()+1)+")")));
+		s.add(new KVP("dds_version_number",getDDSVersionNumber()));
+		s.add(new KVP("display_window_flag",getDisplayWindowFlag()));
+		s.add(new KVP("display_width",getDisplayWidth()).setDescription("("+(getDisplayWidth()+1)+")"));
+		s.add(new KVP("display_height",getDisplayHeight()).setDescription("("+(getDisplayHeight()+1)+")"));
 		if(getDisplayWindowFlag()==1){
-			s.add(new DefaultMutableTreeNode(new KVP("display_window_horizontal_position_minimum",getDisplayWindowHorizontalPositionMinimum(),null)));
-			s.add(new DefaultMutableTreeNode(new KVP("display_window_horizontal_position_maximum",getDisplayWindowHorizontalPositionMaximum(),null)));
-			s.add(new DefaultMutableTreeNode(new KVP("display_window_vertical_position_minimum",getDisplayWindowVerticalPositionMinimum(),null)));
-			s.add(new DefaultMutableTreeNode(new KVP("display_window_vertical_position_maximum",getDisplayWindowVerticalPositionMaximum(),null)));
+			s.add(new KVP("display_window_horizontal_position_minimum",getDisplayWindowHorizontalPositionMinimum()));
+			s.add(new KVP("display_window_horizontal_position_maximum",getDisplayWindowHorizontalPositionMaximum()));
+			s.add(new KVP("display_window_vertical_position_minimum",getDisplayWindowVerticalPositionMinimum()));
+			s.add(new KVP("display_window_vertical_position_maximum",getDisplayWindowVerticalPositionMaximum()));
 
 		}
 

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/dvbsubtitling/DisplayDefinitionSegment.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/dvbsubtitling/DisplayDefinitionSegment.java
@@ -41,8 +41,8 @@ public class DisplayDefinitionSegment extends Segment implements TreeNode{
 	}
 
 	@Override
-	public DefaultMutableTreeNode getJTreeNode(final int modus) {
-		final DefaultMutableTreeNode s = super.getJTreeNode(modus);
+	public KVP getJTreeNode(final int modus) {
+		final KVP s = super.getJTreeNode(modus);
 		s.add(new DefaultMutableTreeNode(new KVP("dds_version_number",getDDSVersionNumber(),null)));
 		s.add(new DefaultMutableTreeNode(new KVP("display_window_flag",getDisplayWindowFlag(),null)));
 		s.add(new DefaultMutableTreeNode(new KVP("display_width",getDisplayWidth(),"("+(getDisplayWidth()+1)+")")));

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/dvbsubtitling/DisplaySet.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/dvbsubtitling/DisplaySet.java
@@ -68,7 +68,7 @@ public class DisplaySet implements TreeNode, ImageSource {
 
 	@Override
 	public DefaultMutableTreeNode getJTreeNode(final int modus) {
-		final DefaultMutableTreeNode t=new DefaultMutableTreeNode(new KVP("Display Set",this));
+		final DefaultMutableTreeNode t=new DefaultMutableTreeNode(new KVP("Display Set").addImageSource(this, "Display Set"));
 		t.add(new DefaultMutableTreeNode(new KVP("pts",pts, printTimebase90kHz(pts))));
 		addListJTree(t, segments, modus, "segments");
 

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/dvbsubtitling/DisplaySet.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/dvbsubtitling/DisplaySet.java
@@ -2,7 +2,7 @@
  *
  *  http://www.digitalekabeltelevisie.nl/dvb_inspector
  *
- *  This code is Copyright 2009-2012 by Eric Berendsen (e_berendsen@digitalekabeltelevisie.nl)
+ *  This code is Copyright 2009-2024 by Eric Berendsen (e_berendsen@digitalekabeltelevisie.nl)
  *
  *  This file is part of DVB Inspector.
  *
@@ -36,7 +36,6 @@ import java.awt.image.*;
 import java.util.*;
 import java.util.List;
 
-import javax.swing.tree.DefaultMutableTreeNode;
 
 import nl.digitalekabeltelevisie.controller.*;
 import nl.digitalekabeltelevisie.data.mpeg.pes.GeneralPesHandler;
@@ -45,7 +44,7 @@ import nl.digitalekabeltelevisie.gui.ImageSource;
 public class DisplaySet implements TreeNode, ImageSource {
 
 
-	private List<Segment>  segments = new ArrayList<Segment>();
+	private List<Segment>  segments = new ArrayList<>();
 	// all sets up to and including this one from start of epoch ("mode change" or "acquisition point")
 	// so all we need to draw image
 	private List<DisplaySet> epoch = null;
@@ -67,9 +66,9 @@ public class DisplaySet implements TreeNode, ImageSource {
 	}
 
 	@Override
-	public DefaultMutableTreeNode getJTreeNode(final int modus) {
-		final DefaultMutableTreeNode t=new DefaultMutableTreeNode(new KVP("Display Set").addImageSource(this, "Display Set"));
-		t.add(new DefaultMutableTreeNode(new KVP("pts",pts, printTimebase90kHz(pts))));
+	public KVP getJTreeNode(final int modus) {
+		final KVP t = new KVP("Display Set").addImageSource(this, "Display Set");
+		t.add(new KVP("pts", pts).setDescription(printTimebase90kHz(pts)));
 		addListJTree(t, segments, modus, "segments");
 
 		return t;
@@ -106,13 +105,13 @@ public class DisplaySet implements TreeNode, ImageSource {
 			final CLUTDefinitionSegment cluts[] = new CLUTDefinitionSegment[256];
 			final DisplaySet initDisplaySet = epoch.get(0);
 			final List<Segment> initDisplaySegments = initDisplaySet.getSegments();
-			final Map<Integer, ObjectDataSegment> objects = new HashMap<Integer,ObjectDataSegment>();
+			final Map<Integer, ObjectDataSegment> objects = new HashMap<>();
 			DisplayDefinitionSegment displayDefinitionSegment = null;
 			PageCompositionSegment lastPCS = null;
 
 			// which segment are we processing
 
-			List<RegionCompositionSegment> localRegions = new ArrayList<RegionCompositionSegment>();
+			List<RegionCompositionSegment> localRegions = new ArrayList<>();
 			for (final Segment segment : initDisplaySegments) {
 
 				if(segment.getSegmentType()==0x14){ // display definition segment
@@ -170,9 +169,10 @@ public class DisplaySet implements TreeNode, ImageSource {
 			// now loop over other sets
 			int k=1;
 			while(k< epoch.size()){
-				final DisplaySet displaySet = epoch.get(k++);
+				final DisplaySet displaySet = epoch.get(k);
+				k++;
 				// used to remember which regions are in this set, because we need to update them with the objects later
-				localRegions = new ArrayList<RegionCompositionSegment>();
+				localRegions = new ArrayList<>();
 				final List<Segment> segmentList = displaySet.getSegments();
 				for (final Segment segment : segmentList) {
 					if(segment.getSegmentType()==0x10 ){// page composition segment,
@@ -227,9 +227,8 @@ public class DisplaySet implements TreeNode, ImageSource {
 			}
 
 			return res;
-		}else{ // no epoch
-			return null;
 		}
+		return null;
 	}
 
 	private static void paintObjectsOnRegions(final Map<Integer, ObjectDataSegment> objects,

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/dvbsubtitling/DisplaySet.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/dvbsubtitling/DisplaySet.java
@@ -52,7 +52,7 @@ public class DisplaySet implements TreeNode, ImageSource {
 
 	private long pts = 0;
 
-	public DisplaySet(final GeneralPesHandler pesHandler, final long pts) {
+	public DisplaySet(GeneralPesHandler pesHandler, long pts) {
 		this.pesHandler = pesHandler;
 		this.pts = pts;
 	}
@@ -61,13 +61,13 @@ public class DisplaySet implements TreeNode, ImageSource {
 		return pts;
 	}
 
-	public void setPts(final long pts) {
+	public void setPts(long pts) {
 		this.pts = pts;
 	}
 
 	@Override
-	public KVP getJTreeNode(final int modus) {
-		final KVP t = new KVP("Display Set").addImageSource(this, "Display Set");
+	public KVP getJTreeNode(int modus) {
+		KVP t = new KVP("Display Set").addImageSource(this, "Display Set");
 		t.add(new KVP("pts", pts).setDescription(printTimebase90kHz(pts)));
 		addListJTree(t, segments, modus, "segments");
 
@@ -100,19 +100,19 @@ public class DisplaySet implements TreeNode, ImageSource {
 	public BufferedImage getImage() {
 		BufferedImage res = null;
 		if(epoch!=null){
-			final RegionCompositionSegment regions[] = new RegionCompositionSegment [256];
-			final WritableRaster regionRaster[] = new WritableRaster[256];
-			final CLUTDefinitionSegment cluts[] = new CLUTDefinitionSegment[256];
-			final DisplaySet initDisplaySet = epoch.get(0);
-			final List<Segment> initDisplaySegments = initDisplaySet.getSegments();
-			final Map<Integer, ObjectDataSegment> objects = new HashMap<>();
+			RegionCompositionSegment[] regions = new RegionCompositionSegment [256];
+			WritableRaster[] regionRaster = new WritableRaster[256];
+			CLUTDefinitionSegment[] cluts = new CLUTDefinitionSegment[256];
+			DisplaySet initDisplaySet = epoch.getFirst();
+			List<Segment> initDisplaySegments = initDisplaySet.getSegments();
+			Map<Integer, ObjectDataSegment> objects = new HashMap<>();
 			DisplayDefinitionSegment displayDefinitionSegment = null;
 			PageCompositionSegment lastPCS = null;
 
 			// which segment are we processing
 
 			List<RegionCompositionSegment> localRegions = new ArrayList<>();
-			for (final Segment segment : initDisplaySegments) {
+			for (Segment segment : initDisplaySegments) {
 
 				if(segment.getSegmentType()==0x14){ // display definition segment
 					displayDefinitionSegment = (DisplayDefinitionSegment)segment;
@@ -120,43 +120,36 @@ public class DisplaySet implements TreeNode, ImageSource {
 
 
 				if(segment.getSegmentType()==0x10 ){// page composition segment, should be present at start of epoch
-					final PageCompositionSegment pcSegment = (PageCompositionSegment)segment;
-					lastPCS = pcSegment;
+                    lastPCS = (PageCompositionSegment)segment;
 				}
 				if(segment.getSegmentType()==0x11){ // region composition
-					final RegionCompositionSegment rcs = (RegionCompositionSegment)segment;
+					RegionCompositionSegment rcs = (RegionCompositionSegment)segment;
 					regions[rcs.getRegionId()] = rcs;
 					localRegions.add(rcs);
 				}
 				if(segment.getSegmentType()==0x12){ // CLUT
-					final CLUTDefinitionSegment cds = (CLUTDefinitionSegment)segment;
+					CLUTDefinitionSegment cds = (CLUTDefinitionSegment)segment;
 					cluts[cds.getCLUTId()] = cds;
 
 				}
 				if(segment.getSegmentType()==0x13){ // object data segment
-					final ObjectDataSegment ods = (ObjectDataSegment)segment;
+					ObjectDataSegment ods = (ObjectDataSegment)segment;
 					objects.put(ods.getObjectId(), ods);
 				}
 			}
 			// create raster for all regions, and fill immediately
 			for (int j = 0; j < regions.length; j++) {
-				final RegionCompositionSegment rcs = regions[j];
+				RegionCompositionSegment rcs = regions[j];
 				if(rcs!=null){
 					//fill the region's, ignore the fill flag, it has to be done anyway
-					int index = 0;
-					switch (rcs.getRegionDepth()) {
-					case 1: // 2 bit
-						index = rcs.getRegion2BitPixelCode();
-						break;
-					case 2: // 4 bit.
-						index = rcs.getRegion4BitPixelCode();
-						break;
-					case 3:
-						index = rcs.getRegion8BitPixelCode();
-						break;
-					}
-					//create new byte[] to fill
-					final byte[] dataArray = new byte[rcs.getRegionHeight() * rcs.getRegionWidth()];
+					int index = switch (rcs.getRegionDepth()) {
+                        case 1 -> rcs.getRegion2BitPixelCode(); // 2 bit
+                        case 2 -> rcs.getRegion4BitPixelCode(); // 4 bit.
+                        case 3 -> rcs.getRegion8BitPixelCode();
+                        default -> 0;
+                    };
+                    //create new byte[] to fill
+					byte[] dataArray = new byte[rcs.getRegionHeight() * rcs.getRegionWidth()];
 					Arrays.fill(dataArray, getInt2UnsignedByte(index));
 					regionRaster[j] = Raster.createInterleavedRaster(new DataBufferByte(dataArray, rcs.getRegionWidth() * rcs.getRegionHeight()),rcs.getRegionWidth(),rcs.getRegionHeight(),rcs.getRegionWidth(),1,new int[]{0},null);
 				}
@@ -169,24 +162,23 @@ public class DisplaySet implements TreeNode, ImageSource {
 			// now loop over other sets
 			int k=1;
 			while(k< epoch.size()){
-				final DisplaySet displaySet = epoch.get(k);
+				DisplaySet displaySet = epoch.get(k);
 				k++;
 				// used to remember which regions are in this set, because we need to update them with the objects later
 				localRegions = new ArrayList<>();
-				final List<Segment> segmentList = displaySet.getSegments();
-				for (final Segment segment : segmentList) {
+				List<Segment> segmentList = displaySet.getSegments();
+				for (Segment segment : segmentList) {
 					if(segment.getSegmentType()==0x10 ){// page composition segment,
-						final PageCompositionSegment pcSegment = (PageCompositionSegment)segment;
-						lastPCS = pcSegment;
+                        lastPCS = (PageCompositionSegment)segment;
 					}else if(segment.getSegmentType()==0x11){ // region composition
-						final RegionCompositionSegment rcs = (RegionCompositionSegment)segment;
+						RegionCompositionSegment rcs = (RegionCompositionSegment)segment;
 						regions[rcs.getRegionId()] = rcs;
 						localRegions.add(rcs);
 					}else if(segment.getSegmentType()==0x12){ // CLUT
-						final CLUTDefinitionSegment cds = (CLUTDefinitionSegment)segment;
+						CLUTDefinitionSegment cds = (CLUTDefinitionSegment)segment;
 						cluts[cds.getCLUTId()] = cds;
 					}else if(segment.getSegmentType()==0x13){ // object data segment
-						final ObjectDataSegment ods = (ObjectDataSegment)segment;
+						ObjectDataSegment ods = (ObjectDataSegment)segment;
 						objects.put(ods.getObjectId(), ods);
 					}
 				}// got all segments, now update regions
@@ -208,19 +200,19 @@ public class DisplaySet implements TreeNode, ImageSource {
 				}
 
 			}
-			final BufferedImage bgImage = pesHandler.getBGImage(height, width,pts);
+			BufferedImage bgImage = pesHandler.getBGImage(height, width,pts);
 			res = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
-			final Graphics2D resGraphics = res.createGraphics();
+			Graphics2D resGraphics = res.createGraphics();
 			resGraphics.drawImage(bgImage,0,0,null);
 
 			// do the actual drawing
 			if(lastPCS!=null){
-				for(final PageCompositionSegment.Region region :lastPCS.getRegions()){
-					final RegionCompositionSegment regionCompositionSegment = regions[region.getRegion_id()];
+				for(PageCompositionSegment.Region region :lastPCS.getRegions()){
+					RegionCompositionSegment regionCompositionSegment = regions[region.getRegion_id()];
 					if(regionCompositionSegment!=null){
-						final WritableRaster regionRaste = regionRaster[region.getRegion_id()];
-						final IndexColorModel iColorModel = cluts[regionCompositionSegment.getCLUTId()].getColorModel(regionCompositionSegment.getRegionDepth());
-						final BufferedImage img = new BufferedImage(iColorModel, regionRaste, false, null);
+						WritableRaster regionRaste = regionRaster[region.getRegion_id()];
+						IndexColorModel iColorModel = cluts[regionCompositionSegment.getCLUTId()].getColorModel(regionCompositionSegment.getRegionDepth());
+						BufferedImage img = new BufferedImage(iColorModel, regionRaste, false, null);
 						resGraphics.drawImage(img, region.getRegion_horizontal_address()+x_offset, region.getRegion_vertical_address()+y_offset,null); // no observer
 					}
 				}
@@ -231,42 +223,42 @@ public class DisplaySet implements TreeNode, ImageSource {
 		return null;
 	}
 
-	private static void paintObjectsOnRegions(final Map<Integer, ObjectDataSegment> objects,
-			final List<RegionCompositionSegment> localRegions,
-			final WritableRaster[] regionRaster) {
-		for (final RegionCompositionSegment rcs : localRegions) {
-			for(final RegionCompositionSegment.RegionObject regionObject: rcs.getRegionObjects()){
-				final int object_id = regionObject.getObject_id();
-				final ObjectDataSegment objectDataSegment = objects.get(object_id);
+	private static void paintObjectsOnRegions(Map<Integer, ObjectDataSegment> objects,
+                                              List<RegionCompositionSegment> localRegions,
+                                              WritableRaster[] regionRaster) {
+		for (RegionCompositionSegment rcs : localRegions) {
+			for(RegionCompositionSegment.RegionObject regionObject: rcs.getRegionObjects()){
+				int object_id = regionObject.getObject_id();
+				ObjectDataSegment objectDataSegment = objects.get(object_id);
 
 				if(objectDataSegment != null){
 					if(objectDataSegment.getObjectCodingMethod()==0){ // if bitmap
-						final WritableRaster raster = objectDataSegment.getRaster(rcs.getRegionDepth());
+						WritableRaster raster = objectDataSegment.getRaster(rcs.getRegionDepth());
 						regionRaster[rcs.getRegionId()].setDataElements(regionObject.getObject_horizontal_position(), regionObject.getObject_vertical_position(), raster);
 					}else if(objectDataSegment.getObjectCodingMethod()==1){ // chars
-						final Font font = new Font("Arial", Font.BOLD,30);
+						Font font = new Font("Arial", Font.BOLD,30);
 						// can not draw on raster directly, create img,draw on it and get its raster
 
 						// first determine needed dimensions of image, so create another tmp image to get size
-						final BufferedImage tmp = new BufferedImage(1, 1, BufferedImage.TYPE_BYTE_INDEXED);
+						BufferedImage tmp = new BufferedImage(1, 1, BufferedImage.TYPE_BYTE_INDEXED);
 						Graphics2D g2d = tmp.createGraphics();
 						g2d.setFont(font);
 						g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_OFF);
-						final FontRenderContext fontRenderContext  = g2d.getFontRenderContext();
-						final String txt = objectDataSegment.getCharacter_code_string();
-						final Rectangle2D rect = font.getStringBounds(txt, fontRenderContext);
+						FontRenderContext fontRenderContext  = g2d.getFontRenderContext();
+						String txt = objectDataSegment.getCharacter_code_string();
+						Rectangle2D rect = font.getStringBounds(txt, fontRenderContext);
 
 						// now we can create the image to draw on
 
-						final IndexColorModel icm = CLUTDefinitionSegment.getDefaultColorModel(rcs.getRegionDepth());
-						final BufferedImage tmp2 = new BufferedImage((int)rect.getWidth(),(int)rect.getHeight(),BufferedImage.TYPE_BYTE_INDEXED,icm);
+						IndexColorModel icm = CLUTDefinitionSegment.getDefaultColorModel(rcs.getRegionDepth());
+						BufferedImage tmp2 = new BufferedImage((int)rect.getWidth(),(int)rect.getHeight(),BufferedImage.TYPE_BYTE_INDEXED,icm);
 						g2d = tmp2.createGraphics();
 						g2d.setFont(font);
 						g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_OFF);
 						g2d.setBackground(new Color(icm.getRGB(regionObject.getBackground_pixel_code())));
 						g2d.setColor(new Color(icm.getRGB(regionObject.getForeground_pixel_code())));
 						g2d.drawString(txt, 0, (int)-rect.getY());
-						final WritableRaster raster = tmp2.getRaster();
+						WritableRaster raster = tmp2.getRaster();
 
 						regionRaster[rcs.getRegionId()].setDataElements(regionObject.getObject_horizontal_position(), regionObject.getObject_vertical_position(), raster);
 					}
@@ -275,11 +267,11 @@ public class DisplaySet implements TreeNode, ImageSource {
 		}
 	}
 
-	public void add(final Segment segment) {
+	public void add(Segment segment) {
 		segments.add(segment);
 	}
 
-	public Segment getSegment(final int i) {
+	public Segment getSegment(int i) {
 		return segments.get(i);
 	}
 
@@ -287,7 +279,7 @@ public class DisplaySet implements TreeNode, ImageSource {
 		return epoch;
 	}
 
-	public void setEpoch(final List<DisplaySet> epoch) {
+	public void setEpoch(List<DisplaySet> epoch) {
 		this.epoch = epoch;
 	}
 
@@ -295,7 +287,7 @@ public class DisplaySet implements TreeNode, ImageSource {
 		return pesHandler;
 	}
 
-	public void setPesHandler(final GeneralPesHandler pesHandler) {
+	public void setPesHandler(GeneralPesHandler pesHandler) {
 		this.pesHandler = pesHandler;
 	}
 
@@ -303,7 +295,7 @@ public class DisplaySet implements TreeNode, ImageSource {
 		return segments;
 	}
 
-	public void setSegments(final List<Segment> segments) {
+	public void setSegments(List<Segment> segments) {
 		this.segments = segments;
 	}
 

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/dvbsubtitling/ObjectDataSegment.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/dvbsubtitling/ObjectDataSegment.java
@@ -2,7 +2,7 @@
  *
  *  http://www.digitalekabeltelevisie.nl/dvb_inspector
  *
- *  This code is Copyright 2009-2020 by Eric Berendsen (e_berendsen@digitalekabeltelevisie.nl)
+ *  This code is Copyright 2009-2024 by Eric Berendsen (e_berendsen@digitalekabeltelevisie.nl)
  *
  *  This file is part of DVB Inspector.
  *
@@ -41,7 +41,6 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import javax.swing.tree.DefaultMutableTreeNode;
 
 import nl.digitalekabeltelevisie.controller.KVP;
 import nl.digitalekabeltelevisie.controller.TreeNode;
@@ -59,8 +58,8 @@ public class ObjectDataSegment extends Segment implements ImageSource {
 
 
 	// for coding of pixels
-	private final List<PixelDataSubBlock> topFieldDataBlocks = new ArrayList<PixelDataSubBlock>();
-	private List<PixelDataSubBlock> bottomFieldDataBlocks = new ArrayList<PixelDataSubBlock>();
+	private final List<PixelDataSubBlock> topFieldDataBlocks = new ArrayList<>();
+	private List<PixelDataSubBlock> bottomFieldDataBlocks = new ArrayList<>();
 
 	// For coded as a string of characters
 	private int number_of_codes;
@@ -101,27 +100,27 @@ public class ObjectDataSegment extends Segment implements ImageSource {
 			dataType = getInt(data_block,offset, 1, MASK_8BITS);
 		}
 
-		public DefaultMutableTreeNode getJTreeNode(final int modus) {
-			final DefaultMutableTreeNode s = new DefaultMutableTreeNode(new KVP("pixel-data_sub-block "+getDataTypeString(dataType)));
-			s.add(new DefaultMutableTreeNode(new KVP("data_type",dataType,getDataTypeString(dataType))));
+		public KVP getJTreeNode(final int modus) {
+			final KVP s = new KVP("pixel-data_sub-block "+getDataTypeString(dataType));
+			s.add(new KVP("data_type",dataType).setDescription(getDataTypeString(dataType)));
 			if((dataType >=0x10 )&&(dataType <= 0x12)){ // pixels
-				s.add(new DefaultMutableTreeNode(new KVP("no_pixels",no_pixels,null)));
-				s.add(new DefaultMutableTreeNode(new KVP("pixels",pixels,0,no_pixels,null)));
+				s.add(new KVP("no_pixels",no_pixels));
+				s.add(new KVP("pixels",pixels,0,no_pixels));
 			}else if(dataType ==0x20 ){ // 2_to_4_bit_map_table data
 				if(table_2_to_4_bit_map_table!=null){
 					for (int i = 0; i < table_2_to_4_bit_map_table.length; i++) {
-						s.add(new DefaultMutableTreeNode(new KVP("entry ["+i+"]",table_2_to_4_bit_map_table[i],null)));
+						s.add(new KVP("entry ["+i+"]",table_2_to_4_bit_map_table[i]));
 					}
 				}
 			}else if(dataType ==0x21 ){ // 2_to_8-bit_map-table data data
 				if(table_2_to_8_bit_map_table!=null){
 					for (int i = 0; i < table_2_to_8_bit_map_table.length; i++) {
-						s.add(new DefaultMutableTreeNode(new KVP("entry ["+i+"]",table_2_to_8_bit_map_table[i],null)));
+						s.add(new KVP("entry ["+i+"]",table_2_to_8_bit_map_table[i]));
 					}
 				}
 			}else if((dataType ==0x22)&& (table_4_to_8_bit_map_table!=null)){// 4_to_8-bit_map-table data
 				for (int i = 0; i < table_4_to_8_bit_map_table.length; i++) {
-					s.add(new DefaultMutableTreeNode(new KVP("entry ["+i+"]",table_4_to_8_bit_map_table[i],null)));
+					s.add(new KVP("entry ["+i+"]",table_4_to_8_bit_map_table[i]));
 				}
 			}
 
@@ -470,21 +469,21 @@ public class ObjectDataSegment extends Segment implements ImageSource {
 	@Override
 	public KVP getJTreeNode(final int modus) {
 		final KVP s = super.getJTreeNode(modus).addImageSource(this, "Object Data Segment");
-		s.add(new DefaultMutableTreeNode(new KVP("object_id", getObjectId(), null)));
-		s.add(new DefaultMutableTreeNode(new KVP("object_version_number", getObjectVersionNumber(), null)));
-		s.add(new DefaultMutableTreeNode(new KVP("object_coding_method", getObjectCodingMethod(), getObjectCodingMethodString(getObjectCodingMethod()))));
-		s.add(new DefaultMutableTreeNode(new KVP("non_modifying_colour_flag", getNonModifyingColourFlag(), null)));
+		s.add(new KVP("object_id", getObjectId()));
+		s.add(new KVP("object_version_number", getObjectVersionNumber()));
+		s.add(new KVP("object_coding_method", getObjectCodingMethod()).setDescription(getObjectCodingMethodString(getObjectCodingMethod())));
+		s.add(new KVP("non_modifying_colour_flag", getNonModifyingColourFlag()));
 		if(getObjectCodingMethod()==0){
-			s.add(new DefaultMutableTreeNode(new KVP("top_field_data_block_length", getTopFieldDataBlockLength(), null)));
-			s.add(new DefaultMutableTreeNode(new KVP("bottom_field_data_block_length", getBottomFieldDataBlockLength(), null)));
+			s.add(new KVP("top_field_data_block_length", getTopFieldDataBlockLength()));
+			s.add(new KVP("bottom_field_data_block_length", getBottomFieldDataBlockLength()));
 			addListJTree(s, topFieldDataBlocks,modus,"top field pixel-data_sub-block");
 			if(getBottomFieldDataBlockLength()!=0){
 				addListJTree(s, bottomFieldDataBlocks,modus,"bottom field pixel-data_sub-block");
 			}
 
 		}else if(getObjectCodingMethod()==1){
-			s.add(new DefaultMutableTreeNode(new KVP("number_of_codes", number_of_codes, null)));
-			s.add(new DefaultMutableTreeNode(new KVP("character_codes", character_code_string, null)));
+			s.add(new KVP("number_of_codes", number_of_codes));
+			s.add(new KVP("character_codes", character_code_string));
 
 		}
 

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/dvbsubtitling/ObjectDataSegment.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/dvbsubtitling/ObjectDataSegment.java
@@ -46,7 +46,7 @@ import nl.digitalekabeltelevisie.controller.KVP;
 import nl.digitalekabeltelevisie.controller.TreeNode;
 import nl.digitalekabeltelevisie.gui.ImageSource;
 import nl.digitalekabeltelevisie.util.BitSource;
-import nl.digitalekabeltelevisie.util.Utils;
+
 
 /**
  * @author Eric Berendsen

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/dvbsubtitling/ObjectDataSegment.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/dvbsubtitling/ObjectDataSegment.java
@@ -468,8 +468,8 @@ public class ObjectDataSegment extends Segment implements ImageSource {
 	 * @see nl.digitalekabeltelevisie.data.mpeg.pes.dvbsubtitling.Segment#getJTreeNode(int)
 	 */
 	@Override
-	public DefaultMutableTreeNode getJTreeNode(final int modus) {
-		final DefaultMutableTreeNode s = super.getJTreeNode(modus,this);
+	public KVP getJTreeNode(final int modus) {
+		final KVP s = super.getJTreeNode(modus).addImageSource(this, "Object Data Segment");
 		s.add(new DefaultMutableTreeNode(new KVP("object_id", getObjectId(), null)));
 		s.add(new DefaultMutableTreeNode(new KVP("object_version_number", getObjectVersionNumber(), null)));
 		s.add(new DefaultMutableTreeNode(new KVP("object_coding_method", getObjectCodingMethod(), getObjectCodingMethodString(getObjectCodingMethod()))));

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/dvbsubtitling/ObjectDataSegment.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/dvbsubtitling/ObjectDataSegment.java
@@ -75,9 +75,6 @@ public class ObjectDataSegment extends Segment implements ImageSource {
 														  };
 
 
-	/**
-	 *
-	 */
 	public static class PixelDataSubBlock implements TreeNode{
 
 		protected byte[] data_block;
@@ -94,14 +91,14 @@ public class ObjectDataSegment extends Segment implements ImageSource {
 		private byte [] table_2_to_8_bit_map_table = null;
 		private byte [] table_4_to_8_bit_map_table = null;
 
-		public PixelDataSubBlock(final byte[] data, final int offset) {
+		public PixelDataSubBlock(byte[] data, int offset) {
 			this.data_block = data;
 			this.offset = offset;
 			dataType = getInt(data_block,offset, 1, MASK_8BITS);
 		}
 
-		public KVP getJTreeNode(final int modus) {
-			final KVP s = new KVP("pixel-data_sub-block "+getDataTypeString(dataType));
+		public KVP getJTreeNode(int modus) {
+			KVP s = new KVP("pixel-data_sub-block "+getDataTypeString(dataType));
 			s.add(new KVP("data_type",dataType).setDescription(getDataTypeString(dataType)));
 			if((dataType >=0x10 )&&(dataType <= 0x12)){ // pixels
 				s.add(new KVP("no_pixels",no_pixels));
@@ -128,14 +125,14 @@ public class ObjectDataSegment extends Segment implements ImageSource {
 		}
 
 
-		public void addPixel(final byte p){
+		public void addPixel(byte p){
 			if(no_pixels>= pixels.length){
 				pixels = Arrays.copyOf(pixels, no_pixels *2);
 			}
 			pixels[no_pixels++] = p;
 		}
 
-		public void addIdenticalPixel(final byte pixel, final int no){
+		public void addIdenticalPixel(byte pixel, int no){
 			if(pixels==null){
 				pixels = new byte[720];
 			}
@@ -152,25 +149,16 @@ public class ObjectDataSegment extends Segment implements ImageSource {
 
 
 
-		/**
-		 * @return the dataType
-		 */
+
 		public int getDataType() {
 			return dataType;
 		}
 
 
-		/**
-		 * @return the no_pixels
-		 */
 		public int getNo_pixels() {
 			return no_pixels;
 		}
 
-
-		/**
-		 * @return the pixels
-		 */
 		public byte[] getPixels() {
 			return pixels;
 		}
@@ -180,7 +168,7 @@ public class ObjectDataSegment extends Segment implements ImageSource {
 			return table_2_to_4_bit_map_table;
 		}
 
-		public void setTable_2_to_4_bit_map_table(final byte[] table_2_to_4_bit_map_table) {
+		public void setTable_2_to_4_bit_map_table(byte[] table_2_to_4_bit_map_table) {
 			this.table_2_to_4_bit_map_table = table_2_to_4_bit_map_table;
 		}
 
@@ -188,7 +176,7 @@ public class ObjectDataSegment extends Segment implements ImageSource {
 			return table_2_to_8_bit_map_table;
 		}
 
-		public void setTable_2_to_8_bit_map_table(final byte[] table_2_to_8_bit_map_table) {
+		public void setTable_2_to_8_bit_map_table(byte[] table_2_to_8_bit_map_table) {
 			this.table_2_to_8_bit_map_table = table_2_to_8_bit_map_table;
 		}
 
@@ -196,16 +184,13 @@ public class ObjectDataSegment extends Segment implements ImageSource {
 			return table_4_to_8_bit_map_table;
 		}
 
-		public void setTable_4_to_8_bit_map_table(final byte[] table_4_to_8_bit_map_table) {
+		public void setTable_4_to_8_bit_map_table(byte[] table_4_to_8_bit_map_table) {
 			this.table_4_to_8_bit_map_table = table_4_to_8_bit_map_table;
 		}
 	}
 
-	/**
-	 * @param data
-	 * @param offset
-	 */
-	public ObjectDataSegment(final byte[] data, final int offset) {
+
+	public ObjectDataSegment(byte[] data, int offset) {
 		super(data, offset);
 
 		if(getObjectCodingMethod()==0){ // coding of pixels
@@ -220,10 +205,10 @@ public class ObjectDataSegment extends Segment implements ImageSource {
 
 		}else if(getObjectCodingMethod()==1){ // coded as a string of characters
 			number_of_codes = getInt(data,offset+9, 1, MASK_8BITS);
-			final int[] text = new int[number_of_codes];
+			int[] text = new int[number_of_codes];
 			int txtLen=0;
 			for(int i = 0; i < number_of_codes; i ++){
-				final int character_code = (int)getLong(data,offset+10+(i*2), 2, MASK_16BITS);
+				int character_code = (int)getLong(data,offset+10+(i*2), 2, MASK_16BITS);
 				if(character_code>=32){ // skip unprintable chars (ugly!, why needed?)
 					text[txtLen++]=character_code;
 				}
@@ -239,20 +224,14 @@ public class ObjectDataSegment extends Segment implements ImageSource {
 		}
 	}
 
-	/**
-	 * @param data
-	 * @param offset
-	 * @param fieldDataBlockLength
-	 * @param processed_length
-	 * @return
-	 */
-	private int readFieldDataBlock(final byte[] data, final int offset, final int fieldDataBlockLength, final List<PixelDataSubBlock> pixelDataSubBlockList) {
+
+	private int readFieldDataBlock(byte[] data, int offset, int fieldDataBlockLength, List<PixelDataSubBlock> pixelDataSubBlockList) {
 		int processed_length = 0;
 		while((processed_length < fieldDataBlockLength)&&isMoreDataAvaliable(offset, processed_length)){
-			final int blockStart = offset + processed_length;
-			final int dataType = getInt(data_block,blockStart, 1, MASK_8BITS);
-			final PixelDataSubBlock b = new PixelDataSubBlock(data, blockStart);
-			final BitSource bs = new BitSource(data, blockStart+1);
+			int blockStart = offset + processed_length;
+			int dataType = getInt(data_block,blockStart, 1, MASK_8BITS);
+			PixelDataSubBlock b = new PixelDataSubBlock(data, blockStart);
+			BitSource bs = new BitSource(data, blockStart+1);
 
 			switch (dataType) {
 			case 0x10: // 2-bit/pixel code string
@@ -284,32 +263,26 @@ public class ObjectDataSegment extends Segment implements ImageSource {
 		return processed_length;
 	}
 
-	private boolean isMoreDataAvaliable(final int offset, int processed_length) {
-		final boolean moreDataAvailable = (offset + processed_length)<data_block.length;
+	private boolean isMoreDataAvaliable(int offset, int processed_length) {
+		boolean moreDataAvailable = (offset + processed_length)<data_block.length;
 		if(!moreDataAvailable){
 			logger.warning("less data available than expected; (offset:"+offset+"+"+"processed_length:"+processed_length+")>=data_block.length:"+data_block.length);
 		}
 		return moreDataAvailable;
 	}
 
-	/**
-	 * @param bs
-	 * @param b
-	 */
-	private static void two_to_4_bit_map_table(final BitSource bs, final PixelDataSubBlock b) {
-		final byte [] table = new byte[4];
+
+	private static void two_to_4_bit_map_table(BitSource bs, PixelDataSubBlock b) {
+		byte [] table = new byte[4];
 		for (int i = 0; i < 4; i++) {
 			table[i]=(byte)bs.readBits(4);
 		}
 		b.setTable_2_to_4_bit_map_table(table);
 	}
 
-	/**
-	 * @param bs
-	 * @param b
-	 */
-	private static void two_to_8_bit_map_table(final BitSource bs, final PixelDataSubBlock b) {
-		final byte [] table = new byte[4];
+
+	private static void two_to_8_bit_map_table(BitSource bs, PixelDataSubBlock b) {
+		byte [] table = new byte[4];
 		for (int i = 0; i < 4; i++) {
 			table[i]=bs.readSignedByte(8);
 		}
@@ -320,8 +293,8 @@ public class ObjectDataSegment extends Segment implements ImageSource {
 	 * @param bs
 	 * @param b
 	 */
-	private static void four_to_8_bit_map_table(final BitSource bs, final PixelDataSubBlock b) {
-		final byte [] table = new byte[16];
+	private static void four_to_8_bit_map_table(BitSource bs, PixelDataSubBlock b) {
+		byte [] table = new byte[16];
 		for (int i = 0; i < 4; i++) {
 			table[i]=bs.readSignedByte(8);
 		}
@@ -333,32 +306,32 @@ public class ObjectDataSegment extends Segment implements ImageSource {
 	 * @param bs
 	 * @param b
 	 */
-	private static void two_bit_pixel_code_string(final BitSource bs, final PixelDataSubBlock b) {
+	private static void two_bit_pixel_code_string(BitSource bs, PixelDataSubBlock b) {
 
 		boolean readMore = true;
 		do{
-			final int bits = bs.readBits(2);
+			int bits = bs.readBits(2);
 			if (bits != 0) {
 				b.addPixel((byte)bits);
 			} else {
-				final int switch_1= bs.readBits(1); //switch_1 1 bslbf
+				int switch_1= bs.readBits(1); //switch_1 1 bslbf
 
 				if (switch_1 == 1) {
-					final int run_length_3_10 = bs.readBits(3);
-					final int two_bit_pixel_code = bs.readBits(2);
+					int run_length_3_10 = bs.readBits(3);
+					int two_bit_pixel_code = bs.readBits(2);
 					b.addIdenticalPixel((byte)two_bit_pixel_code,run_length_3_10+3);
 				} else {
-					final int switch_2 = bs.readBits(1); // switch_21 bslbf
+					int switch_2 = bs.readBits(1); // switch_21 bslbf
 					if (switch_2 == 0) {
-						final int switch_3 = bs.readBits(2); //switch_3 2 bslbf
+						int switch_3 = bs.readBits(2); //switch_3 2 bslbf
 						if(switch_3 == 2){ // (switch_3 == '10') {
-							final int run_length_12_27 = bs.readBits(4);
-							final int two_bit_pixel_code = bs.readBits(2);
+							int run_length_12_27 = bs.readBits(4);
+							int two_bit_pixel_code = bs.readBits(2);
 							b.addIdenticalPixel((byte)two_bit_pixel_code,run_length_12_27+12);
 						}
 						if (switch_3 == 3) {//switch_3 == '11'
-							final int run_length_29_284 = bs.readBits(8);// 8 uimsbf
-							final int two_bit_pixel_code = bs.readBits(2);
+							int run_length_29_284 = bs.readBits(8);// 8 uimsbf
+							int two_bit_pixel_code = bs.readBits(2);
 							b.addIdenticalPixel((byte)two_bit_pixel_code,run_length_29_284+29);
 						}
 						if(switch_3 == 0 ){ // not in spec, but we have to stop somewhere, see 11 Structure of the pixel code strings (informative) ETSI EN 300 743 V1.3.1 (2006-11)
@@ -379,7 +352,7 @@ public class ObjectDataSegment extends Segment implements ImageSource {
 	 * @param bs
 	 * @param b
 	 */
-	private static void four_bit_pixel_code_string(final BitSource bs, final PixelDataSubBlock b) {
+	private static void four_bit_pixel_code_string(BitSource bs, PixelDataSubBlock b) {
 
 		boolean readMore = true;
 		do {
@@ -387,28 +360,28 @@ public class ObjectDataSegment extends Segment implements ImageSource {
 				readMore = false;
 				logger.warning("bits available: "+bs.available());
 			} else {
-				final int bits = bs.readBits(4);
+				int bits = bs.readBits(4);
 				if (bits != 0) { //if (nextbits() != '0000') {
 					b.addPixel((byte) bits); // 4-bit_pixel-code 4 bslbf
 				} else {
 					// 4-bit_zero 4 bslbf
-					final int switch_1 = bs.readBits(1);// switch_1 1 bslbf
+					int switch_1 = bs.readBits(1);// switch_1 1 bslbf
 					if (switch_1 == 0) { // if (switch_1 == '0') {
-						final int nextbits = bs.readBits(3);//if (nextbits() != '000')
+						int nextbits = bs.readBits(3);//if (nextbits() != '000')
 						if (nextbits != 000) {
-							final int run_length_3_9 = nextbits;
+							int run_length_3_9 = nextbits;
 							b.addIdenticalPixel((byte) 0, run_length_3_9 + 2);
 						} else {
 							readMore = false; //end_of_string_signal 3 bslbf
 						}
 					} else {
-						final int switch_2 = bs.readBits(1); //switch_2 1 bslbf
+						int switch_2 = bs.readBits(1); //switch_2 1 bslbf
 						if (switch_2 == 0) {
-							final int run_length_4_7 = bs.readBits(2);//  2 bslbf
-							final int pixel_code = bs.readBits(4);// 4 bslbf
+							int run_length_4_7 = bs.readBits(2);//  2 bslbf
+							int pixel_code = bs.readBits(4);// 4 bslbf
 							b.addIdenticalPixel((byte) pixel_code, run_length_4_7 + 4);
 						} else {
-							final int switch_3 = bs.readBits(2);//switch_3 2 bslbf
+							int switch_3 = bs.readBits(2);//switch_3 2 bslbf
 							if (switch_3 == 0) { //if (switch_3 == '0') {
 								b.addPixel((byte) 0);
 							}
@@ -416,13 +389,13 @@ public class ObjectDataSegment extends Segment implements ImageSource {
 								b.addIdenticalPixel((byte) 0, 2);
 							}
 							if (switch_3 == 2) { //if (switch_3 == '10') {
-								final int run_length_9_24 = bs.readBits(4);//4 uimsbf
-								final int pixel_code = bs.readBits(4);// 4 bslbf
+								int run_length_9_24 = bs.readBits(4);//4 uimsbf
+								int pixel_code = bs.readBits(4);// 4 bslbf
 								b.addIdenticalPixel((byte) pixel_code, run_length_9_24 + 9);
 							}
 							if (switch_3 == 3) {//	if (switch_3 == '11') {
-								final int run_length_25_280 = bs.readBits(8);//8 uimsbf
-								final int pixel_code = bs.readBits(4);// 4 bslbf
+								int run_length_25_280 = bs.readBits(8);//8 uimsbf
+								int pixel_code = bs.readBits(4);// 4 bslbf
 								b.addIdenticalPixel((byte) pixel_code, run_length_25_280 + 25);
 							}
 						}
@@ -436,28 +409,28 @@ public class ObjectDataSegment extends Segment implements ImageSource {
 	 * @param bs
 	 * @param b
 	 */
-	private static void eigth_bit_pixel_code_string(final BitSource bs, final PixelDataSubBlock b) {
+	private static void eigth_bit_pixel_code_string(BitSource bs, PixelDataSubBlock b) {
 
 		boolean readMore = true;
 		do{
-			final int bits = bs.readBits(8);
+			int bits = bs.readBits(8);
 			if (bits != 0) { //if (nextbits() != '0000') {
-				b.addPixel(Utils.getInt2UnsignedByte(bits)); // 8-bit_pixel-code 8 bslbf
+				b.addPixel(getInt2UnsignedByte(bits)); // 8-bit_pixel-code 8 bslbf
 			} else {
 				// 8-bit_zero 4 bslbf
-				final int switch_1 = bs.readBits(1);// switch_1 1 bslbf
+				int switch_1 = bs.readBits(1);// switch_1 1 bslbf
 				if (switch_1 == 0) { // if (switch_1 == '0') {
-					final int nextbits = bs.readBits(7);//if (nextbits() != '0000 0000') {
+					int nextbits = bs.readBits(7);//if (nextbits() != '0000 0000') {
 					if(nextbits !=0){
-						final int run_length_1_127 = nextbits;
+						int run_length_1_127 = nextbits;
 						b.addIdenticalPixel((byte)0,run_length_1_127);
 					} else{
 						readMore = false; //end_of_string_signal 3 bslbf
 					}
 				}else{
-					final int run_length_3_127= bs.readBits(7);//  2 bslbf
-					final int pixel_code = bs.readBits(8) ;// 4 bslbf
-					b.addIdenticalPixel(Utils.getInt2UnsignedByte(pixel_code),run_length_3_127);
+					int run_length_3_127= bs.readBits(7);//  2 bslbf
+					int pixel_code = bs.readBits(8) ;// 4 bslbf
+					b.addIdenticalPixel(getInt2UnsignedByte(pixel_code),run_length_3_127);
 				}
 			}
 		}while(readMore);
@@ -467,8 +440,8 @@ public class ObjectDataSegment extends Segment implements ImageSource {
 	 * @see nl.digitalekabeltelevisie.data.mpeg.pes.dvbsubtitling.Segment#getJTreeNode(int)
 	 */
 	@Override
-	public KVP getJTreeNode(final int modus) {
-		final KVP s = super.getJTreeNode(modus).addImageSource(this, "Object Data Segment");
+	public KVP getJTreeNode(int modus) {
+		KVP s = super.getJTreeNode(modus).addImageSource(this, "Object Data Segment");
 		s.add(new KVP("object_id", getObjectId()));
 		s.add(new KVP("object_version_number", getObjectVersionNumber()));
 		s.add(new KVP("object_coding_method", getObjectCodingMethod()).setDescription(getObjectCodingMethodString(getObjectCodingMethod())));
@@ -508,7 +481,7 @@ public class ObjectDataSegment extends Segment implements ImageSource {
 	/**
 	 * @return
 	 */
-	public final int getObjectCodingMethod() {
+	public int getObjectCodingMethod() {
 		return getInt(data_block, offset + 8, 1, 0x0C) >> 2;
 	}
 
@@ -541,21 +514,15 @@ public class ObjectDataSegment extends Segment implements ImageSource {
 	 * @param type
 	 * @return
 	 */
-	public static String getObjectCodingMethodString(final int type) {
+	public static String getObjectCodingMethodString(int type) {
 
-		switch (type) {
-
-		case 0x0:
-			return "coding of pixels";
-		case 0x1:
-			return "coded as a string of characters";
-		case 0x2:
-			return "progressive coding of pixels";
-		case 0x3:
-			return "reserved";
-		default:
-			return "Illegal value";
-		}
+        return switch (type) {
+            case 0x0 -> "coding of pixels";
+            case 0x1 -> "coded as a string of characters";
+            case 0x2 -> "progressive coding of pixels";
+            case 0x3 -> "reserved";
+            default -> "Illegal value";
+        };
 	}
 
 
@@ -563,45 +530,32 @@ public class ObjectDataSegment extends Segment implements ImageSource {
 	 * @param type
 	 * @return
 	 */
-	public static String getDataTypeString(final int type) {
+	public static String getDataTypeString(int type) {
 
-		switch (type) {
-
-
-		case 0x10 :
-			return "2-bit/pixel code string";
-		case 0x11 :
-			return "4-bit/pixel code string";
-		case 0x12 :
-			return "8-bit/pixel code string";
-		case 0x20 :
-			return "2_to_4-bit_map-table data";
-		case 0x21 :
-			return "2_to_8-bit_map-table data";
-		case 0x22 :
-			return "4_to_8-bit_map-table data";
-		case 0xF0 :
-			return "end of object line code";
-		default:
-			return "reserved";
-		}
+        return switch (type) {
+            case 0x10 -> "2-bit/pixel code string";
+            case 0x11 -> "4-bit/pixel code string";
+            case 0x12 -> "8-bit/pixel code string";
+            case 0x20 -> "2_to_4-bit_map-table data";
+            case 0x21 -> "2_to_8-bit_map-table data";
+            case 0x22 -> "4_to_8-bit_map-table data";
+            case 0xF0 -> "end of object line code";
+            default -> "reserved";
+        };
 	}
 
-	/* (non-Javadoc)
-	 * @see nl.digitalekabeltelevisie.gui.ImageSource#getImage()
-	 */
 	public BufferedImage getImage() {
 
 		// check for objectCodingMethod characters (like in 07-20_CINE SKY (por)_Um Espírito Atrás de Mim_01.ts, PID 1036, segment 19
 
 		if(getObjectCodingMethod()==0){
 			BufferedImage bi=null;
-			final WritableRaster wr = getRaster(2);
+			WritableRaster wr = getRaster(2);
 			if(wr==null){
 				return null;
 			}
 
-			final IndexColorModel cm =  CLUTDefinitionSegment.getDefault_CLUT_8bitColorModel();
+			IndexColorModel cm =  CLUTDefinitionSegment.getDefault_CLUT_8bitColorModel();
 
 			bi = new BufferedImage(cm, wr, false, null);
 			return bi;
@@ -635,7 +589,7 @@ public class ObjectDataSegment extends Segment implements ImageSource {
 	 * @param regionDepth 1=2 bits, 2=4 bits, 3= 8 bits
 	 * @return
 	 */
-	public WritableRaster getRaster(final int regionDepth) {
+	public WritableRaster getRaster(int regionDepth) {
 		if(getObjectCodingMethod()!=0){ // only for bitmaps
 			return null;
 		}
@@ -649,8 +603,8 @@ public class ObjectDataSegment extends Segment implements ImageSource {
 
 		// first count lines (heigth) and width.
 		int linewidth = 0;
-		for(final PixelDataSubBlock block: topFieldDataBlocks){
-			final int dataType = block.getDataType();
+		for(PixelDataSubBlock block: topFieldDataBlocks){
+			int dataType = block.getDataType();
 			if((dataType>=0x10)&&(dataType<=0x12)){
 				linewidth += block.getNo_pixels();
 			}else if(dataType==0xF0){ // end of object line code
@@ -663,8 +617,8 @@ public class ObjectDataSegment extends Segment implements ImageSource {
 		}
 
 
-		for(final PixelDataSubBlock block: bottomFieldDataBlocks){
-			final int dataType = block.getDataType();
+		for(PixelDataSubBlock block: bottomFieldDataBlocks){
+			int dataType = block.getDataType();
 			if((dataType>=0x10)&&(dataType<=0x12)){
 				linewidth += block.getNo_pixels();
 			}else if(dataType==0xF0){ // end of object line code
@@ -683,7 +637,7 @@ public class ObjectDataSegment extends Segment implements ImageSource {
 
 		height = topLines + bottomLines;
 
-		final byte[] dataBuffer = new byte[height * width];
+		byte[] dataBuffer = new byte[height * width];
 
 		int line=0;
 		int linepos = 0;
@@ -692,13 +646,13 @@ public class ObjectDataSegment extends Segment implements ImageSource {
 		byte [] two_to_8_bit_map_table = default_2_to_8_bit_map_table ;
 		byte [] four_to_8_bit_map_table = default_4_to_8_bit_map_table;
 
-		for(final PixelDataSubBlock block: topFieldDataBlocks){
-			final int dataType = block.getDataType();
+		for(PixelDataSubBlock block: topFieldDataBlocks){
+			int dataType = block.getDataType();
 			if((dataType>=0x10)&&(dataType<=0x12)){
 				if((dataType-15)>=regionDepth){ // ugly hack, means depth of block > requested depth, so no need to remap
 					System.arraycopy(block.getPixels(), 0, dataBuffer, (2*line*width)+linepos, block.getNo_pixels());
 				}else{ // remap
-					final byte[] remappedPix = mapTable(regionDepth,
+					byte[] remappedPix = mapTable(regionDepth,
 							two_to_4_bit_map_table, two_to_8_bit_map_table,
 							four_to_8_bit_map_table, block, dataType);
 					System.arraycopy(remappedPix, 0, dataBuffer, (2*line*width)+linepos, block.getNo_pixels());
@@ -724,13 +678,13 @@ public class ObjectDataSegment extends Segment implements ImageSource {
 		two_to_8_bit_map_table = default_2_to_8_bit_map_table ;
 		four_to_8_bit_map_table = default_4_to_8_bit_map_table;
 
-		for(final PixelDataSubBlock block: bottomFieldDataBlocks){
-			final int dataType = block.getDataType();
+		for(PixelDataSubBlock block: bottomFieldDataBlocks){
+			int dataType = block.getDataType();
 			if((dataType>=0x10)&&(dataType<=0x12)){
 				if((dataType-15)>=regionDepth){ // ugly hack, means depth of block > requested depth, so no need to remap
 					System.arraycopy(block.getPixels(), 0, dataBuffer, ((1+(2*line))*width)+linepos, block.getNo_pixels());
 				}else{ // remap
-					final byte[] remappedPix = mapTable(regionDepth,
+					byte[] remappedPix = mapTable(regionDepth,
 							two_to_4_bit_map_table, two_to_8_bit_map_table,
 							four_to_8_bit_map_table, block, dataType);
 					System.arraycopy(remappedPix, 0, dataBuffer, ((1+(2*line))*width)+linepos, block.getNo_pixels());
@@ -749,13 +703,13 @@ public class ObjectDataSegment extends Segment implements ImageSource {
 			}
 		}
 
-		final DataBuffer dBuffer = new DataBufferByte(dataBuffer, width * height);
+		DataBuffer dBuffer = new DataBufferByte(dataBuffer, width * height);
 		return Raster.createInterleavedRaster(dBuffer,width,height,width,1,new int[]{0},null);
 	}
 
-	private static byte[] mapTable(final int regionDepth, final byte[] two_to_4_bit_map_table,
-			final byte[] two_to_8_bit_map_table, final byte[] four_to_8_bit_map_table,
-			final PixelDataSubBlock block, final int dataType) {
+	private static byte[] mapTable(int regionDepth, byte[] two_to_4_bit_map_table,
+                                   byte[] two_to_8_bit_map_table, byte[] four_to_8_bit_map_table,
+                                   PixelDataSubBlock block, int dataType) {
 		byte [] useMap;
 		if(dataType==0x10){ // two bits PixelDataSubBlock
 			if(regionDepth==2 ){ // four bits
@@ -766,8 +720,8 @@ public class ObjectDataSegment extends Segment implements ImageSource {
 		}else{ // 0x11, 4 bits PixelDataSubBlock
 			useMap = four_to_8_bit_map_table;
 		}
-		final byte[] orgPix = block.getPixels();
-		final byte[] remappedPix = new byte[block.getNo_pixels()];
+		byte[] orgPix = block.getPixels();
+		byte[] remappedPix = new byte[block.getNo_pixels()];
 		for (int i = 0; i < block.getNo_pixels(); i++) {
 			remappedPix[i]=useMap[orgPix[i]];
 		}

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/dvbsubtitling/PageCompositionSegment.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/dvbsubtitling/PageCompositionSegment.java
@@ -44,7 +44,7 @@ public class PageCompositionSegment extends Segment{
 		private int region_horizontal_address;
 		private int region_vertical_address;
 
-		public Region(final int region_id, final int reserved, final int region_horizontal_address, final int region_vertical_address) {
+		public Region(int region_id, int reserved, int region_horizontal_address, int region_vertical_address) {
 			super();
 			this.region_id = region_id;
 			this.reserved = reserved;
@@ -53,8 +53,8 @@ public class PageCompositionSegment extends Segment{
 		}
 
 		@Override
-		public KVP getJTreeNode(final int modus) {
-			final KVP s = new KVP("Region");
+		public KVP getJTreeNode(int modus) {
+			KVP s = new KVP("Region");
 			s.add(new KVP("region_id",region_id));
 			s.add(new KVP("reserved",reserved));
 			s.add(new KVP("region_horizontal_address",region_horizontal_address));
@@ -96,13 +96,13 @@ public class PageCompositionSegment extends Segment{
 
 	}
 
-	public PageCompositionSegment(final byte[] data,final int offset) {
+	public PageCompositionSegment(byte[] data, int offset) {
 		super(data,offset);
 	}
 
 	@Override
-	public KVP getJTreeNode(final int modus) {
-		final KVP s = super.getJTreeNode(modus);
+	public KVP getJTreeNode(int modus) {
+		KVP s = super.getJTreeNode(modus);
 		s.add(new KVP("page_time_out",getPageTimeOut()));
 		s.add(new KVP("page_version_number",getPageVersionNumber()));
 		s.add(new KVP("page_state",getPageState()).setDescription(DVBSubtitlingPESDataField.getPageStateString(getPageState())));
@@ -137,13 +137,13 @@ public class PageCompositionSegment extends Segment{
 	 * @return
 	 */
 	public List<Region> getRegions() {
-		final List<Region> regions = new ArrayList<>();
+		List<Region> regions = new ArrayList<>();
 		int t = 0;
 		while((t+2)<getSegmentLength()){
-			final int region = getInt(data_block, offset+8+t, 1, MASK_8BITS);
-			final int res = getInt(data_block, offset+9+t, 1, MASK_8BITS);
-			final int hor = getInt(data_block, offset+10+t, 2, MASK_16BITS);
-			final int ver = getInt(data_block, offset+12+t, 2, MASK_16BITS);
+			int region = getInt(data_block, offset+8+t, 1, MASK_8BITS);
+			int res = getInt(data_block, offset+9+t, 1, MASK_8BITS);
+			int hor = getInt(data_block, offset+10+t, 2, MASK_16BITS);
+			int ver = getInt(data_block, offset+12+t, 2, MASK_16BITS);
 			regions.add(new Region(region,res,hor,ver));
 			t+=6;
 		}

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/dvbsubtitling/PageCompositionSegment.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/dvbsubtitling/PageCompositionSegment.java
@@ -101,8 +101,8 @@ public class PageCompositionSegment extends Segment implements TreeNode{
 	}
 
 	@Override
-	public DefaultMutableTreeNode getJTreeNode(final int modus) {
-		final DefaultMutableTreeNode s = super.getJTreeNode(modus);
+	public KVP getJTreeNode(final int modus) {
+		final KVP s = super.getJTreeNode(modus);
 		s.add(new DefaultMutableTreeNode(new KVP("page_time_out",getPageTimeOut(),null)));
 		s.add(new DefaultMutableTreeNode(new KVP("page_version_number",getPageVersionNumber(),null)));
 		s.add(new DefaultMutableTreeNode(new KVP("page_state",getPageState(),DVBSubtitlingPESDataField.getPageStateString(getPageState()))));

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/dvbsubtitling/PageCompositionSegment.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/dvbsubtitling/PageCompositionSegment.java
@@ -2,7 +2,7 @@
  *
  *  http://www.digitalekabeltelevisie.nl/dvb_inspector
  *
- *  This code is Copyright 2009-2012 by Eric Berendsen (e_berendsen@digitalekabeltelevisie.nl)
+ *  This code is Copyright 2009-2024 by Eric Berendsen (e_berendsen@digitalekabeltelevisie.nl)
  *
  *  This file is part of DVB Inspector.
  *
@@ -32,12 +32,11 @@ import static nl.digitalekabeltelevisie.util.Utils.*;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.swing.tree.DefaultMutableTreeNode;
 
 import nl.digitalekabeltelevisie.controller.KVP;
 import nl.digitalekabeltelevisie.controller.TreeNode;
 
-public class PageCompositionSegment extends Segment implements TreeNode{
+public class PageCompositionSegment extends Segment{
 
 	public static class Region implements TreeNode{
 		private int region_id;
@@ -53,12 +52,13 @@ public class PageCompositionSegment extends Segment implements TreeNode{
 			this.region_vertical_address = region_vertical_address;
 		}
 
-		public DefaultMutableTreeNode getJTreeNode(final int modus) {
-			final DefaultMutableTreeNode s = new DefaultMutableTreeNode(new KVP("Region"));
-			s.add(new DefaultMutableTreeNode(new KVP("region_id",region_id,null)));
-			s.add(new DefaultMutableTreeNode(new KVP("reserved",reserved,null)));
-			s.add(new DefaultMutableTreeNode(new KVP("region_horizontal_address",region_horizontal_address,null)));
-			s.add(new DefaultMutableTreeNode(new KVP("region_vertical_address",region_vertical_address,null)));
+		@Override
+		public KVP getJTreeNode(final int modus) {
+			final KVP s = new KVP("Region");
+			s.add(new KVP("region_id",region_id));
+			s.add(new KVP("reserved",reserved));
+			s.add(new KVP("region_horizontal_address",region_horizontal_address));
+			s.add(new KVP("region_vertical_address",region_vertical_address));
 			return s;
 		}
 
@@ -103,9 +103,9 @@ public class PageCompositionSegment extends Segment implements TreeNode{
 	@Override
 	public KVP getJTreeNode(final int modus) {
 		final KVP s = super.getJTreeNode(modus);
-		s.add(new DefaultMutableTreeNode(new KVP("page_time_out",getPageTimeOut(),null)));
-		s.add(new DefaultMutableTreeNode(new KVP("page_version_number",getPageVersionNumber(),null)));
-		s.add(new DefaultMutableTreeNode(new KVP("page_state",getPageState(),DVBSubtitlingPESDataField.getPageStateString(getPageState()))));
+		s.add(new KVP("page_time_out",getPageTimeOut()));
+		s.add(new KVP("page_version_number",getPageVersionNumber()));
+		s.add(new KVP("page_state",getPageState()).setDescription(DVBSubtitlingPESDataField.getPageStateString(getPageState())));
 
 		addListJTree(s, getRegions(),modus,"regions");
 
@@ -137,7 +137,7 @@ public class PageCompositionSegment extends Segment implements TreeNode{
 	 * @return
 	 */
 	public List<Region> getRegions() {
-		final ArrayList<Region> regions = new ArrayList<Region>();
+		final List<Region> regions = new ArrayList<>();
 		int t = 0;
 		while((t+2)<getSegmentLength()){
 			final int region = getInt(data_block, offset+8+t, 1, MASK_8BITS);

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/dvbsubtitling/RegionCompositionSegment.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/dvbsubtitling/RegionCompositionSegment.java
@@ -204,8 +204,8 @@ public class RegionCompositionSegment extends Segment implements TreeNode {
 	 * @see nl.digitalekabeltelevisie.data.mpeg.pes.dvbsubtitling.Segment#getJTreeNode(int)
 	 */
 	@Override
-	public DefaultMutableTreeNode getJTreeNode(final int modus) {
-		final DefaultMutableTreeNode s = super.getJTreeNode(modus);
+	public KVP getJTreeNode(final int modus) {
+		final KVP s = super.getJTreeNode(modus);
 		s.add(new DefaultMutableTreeNode(new KVP("region_id", getRegionId(), null)));
 		s.add(new DefaultMutableTreeNode(new KVP("region_version_number", getRegionVersionNumber(), null)));
 		s.add(new DefaultMutableTreeNode(new KVP("region_fill_flag", getRegionFillFlag(), null)));

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/dvbsubtitling/RegionCompositionSegment.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/dvbsubtitling/RegionCompositionSegment.java
@@ -2,7 +2,7 @@
  *
  *  http://www.digitalekabeltelevisie.nl/dvb_inspector
  *
- *  This code is Copyright 2009-2012 by Eric Berendsen (e_berendsen@digitalekabeltelevisie.nl)
+ *  This code is Copyright 2009-2024 by Eric Berendsen (e_berendsen@digitalekabeltelevisie.nl)
  *
  *  This file is part of DVB Inspector.
  *
@@ -32,71 +32,28 @@ import static nl.digitalekabeltelevisie.util.Utils.*;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.swing.tree.DefaultMutableTreeNode;
-
 import nl.digitalekabeltelevisie.controller.KVP;
 import nl.digitalekabeltelevisie.controller.TreeNode;
 
-/**
- * @author Eric Berendsen
- *
- */
-public class RegionCompositionSegment extends Segment implements TreeNode {
+public class RegionCompositionSegment extends Segment {
 
-	/**
-	 * @author Eric Berendsen
-	 *
-	 */
 	public static class RegionObject implements TreeNode {
-		/**
-		 *
-		 */
 		private int object_id;
 
-		/**
-		 *
-		 */
 		private int object_type;
-
-		/**
-		 *
-		 */
 		private int object_provider_flag;
 
-		/**
-		 *
-		 */
 		private int object_horizontal_position;
 
-		/**
-		 *
-		 */
 		private int object_vertical_position;
-
-		/**
-		 *
-		 */
 		private int foreground_pixel_code = 0;
-
-		/**
-		 *
-		 */
 		private int background_pixel_code = 0;
 
-		/**
-		 * @param object_id
-		 * @param object_type
-		 * @param object_provider_flag
-		 * @param object_horizontal_position
-		 * @param object_vertical_position
-		 * @param foreground_pixel_code
-		 * @param background_pixel_code
-		 */
+
 		public RegionObject(final int object_id, final int object_type,
 				final int object_provider_flag, final int object_horizontal_position,
 				final int object_vertical_position, final int foreground_pixel_code,
 				final int background_pixel_code) {
-			super();
 			this.object_id = object_id;
 			this.object_type = object_type;
 			this.object_provider_flag = object_provider_flag;
@@ -106,211 +63,118 @@ public class RegionCompositionSegment extends Segment implements TreeNode {
 			this.background_pixel_code = background_pixel_code;
 		}
 
-		/* (non-Javadoc)
-		 * @see nl.digitalekabeltelevisie.controller.TreeNode#getJTreeNode(int)
-		 */
-		public DefaultMutableTreeNode getJTreeNode(final int modus) {
-			final DefaultMutableTreeNode s = new DefaultMutableTreeNode(new KVP("Object"));
-			s.add(new DefaultMutableTreeNode(new KVP("object_id", object_id,
-					null)));
-			s.add(new DefaultMutableTreeNode(new KVP("object_type",
-					object_type, getObjectTypeString(object_type))));
-			s.add(new DefaultMutableTreeNode(new KVP("object_provider_flag",
-					object_provider_flag,
-					getObjectProviderString(object_provider_flag))));
-			s.add(new DefaultMutableTreeNode(new KVP(
-					"object_horizontal_position", object_horizontal_position,
-					null)));
-			s
-			.add(new DefaultMutableTreeNode(new KVP(
-					"object_vertical_position",
-					object_vertical_position, null)));
+
+		@Override
+		public KVP getJTreeNode(final int modus) {
+			final KVP s = new KVP("Object");
+			s.add(new KVP("object_id", object_id));
+			s.add(new KVP("object_type", object_type).setDescription(getObjectTypeString(object_type)));
+			s.add(new KVP("object_provider_flag", object_provider_flag)
+					.setDescription(getObjectProviderString(object_provider_flag)));
+			s.add(new KVP("object_horizontal_position", object_horizontal_position));
+			s.add(new KVP("object_vertical_position", object_vertical_position));
 			if ((object_type == 0x01) || (object_type == 0x02)) {
-				s.add(new DefaultMutableTreeNode(new KVP(
-						"foreground_pixel_code", foreground_pixel_code, null)));
-				s.add(new DefaultMutableTreeNode(new KVP(
-						"background_pixel_code", background_pixel_code, null)));
+				s.add(new KVP("foreground_pixel_code", foreground_pixel_code));
+				s.add(new KVP("background_pixel_code", background_pixel_code));
 			}
 			return s;
 		}
 
-
-		/**
-		 * @return the background_pixel_code
-		 */
 		public int getBackground_pixel_code() {
 			return background_pixel_code;
 		}
 
-
-		/**
-		 * @return the foreground_pixel_code
-		 */
 		public int getForeground_pixel_code() {
 			return foreground_pixel_code;
 		}
 
-
-		/**
-		 * @return the object_horizontal_position
-		 */
 		public int getObject_horizontal_position() {
 			return object_horizontal_position;
 		}
 
-
-		/**
-		 * @return the object_id
-		 */
 		public int getObject_id() {
 			return object_id;
 		}
 
-
-		/**
-		 * @return the object_provider_flag
-		 */
 		public int getObject_provider_flag() {
 			return object_provider_flag;
 		}
 
-
-		/**
-		 * @return the object_type
-		 */
 		public int getObject_type() {
 			return object_type;
 		}
 
-
-		/**
-		 * @return the object_vertical_position
-		 */
 		public int getObject_vertical_position() {
 			return object_vertical_position;
 		}
 
 	}
 
-	/**
-	 * @param data
-	 * @param offset
-	 */
 	public RegionCompositionSegment(final byte[] data, final int offset) {
 		super(data, offset);
 	}
 
-	/* (non-Javadoc)
-	 * @see nl.digitalekabeltelevisie.data.mpeg.pes.dvbsubtitling.Segment#getJTreeNode(int)
-	 */
 	@Override
 	public KVP getJTreeNode(final int modus) {
 		final KVP s = super.getJTreeNode(modus);
-		s.add(new DefaultMutableTreeNode(new KVP("region_id", getRegionId(), null)));
-		s.add(new DefaultMutableTreeNode(new KVP("region_version_number", getRegionVersionNumber(), null)));
-		s.add(new DefaultMutableTreeNode(new KVP("region_fill_flag", getRegionFillFlag(), null)));
-		s.add(new DefaultMutableTreeNode(new KVP("region_width", getRegionWidth(), null)));
-		s.add(new DefaultMutableTreeNode(new KVP("region_height", getRegionHeight(), null)));
-		s.add(new DefaultMutableTreeNode(new KVP("region_level_of_compatibility", getRegionLevelOfCompatibility(),
-				getRegionLevelOfCompatibilityString(getRegionLevelOfCompatibility()))));
-		s.add(new DefaultMutableTreeNode(new KVP("region_depth", getRegionDepth(),
-				getRegionDepthString(getRegionDepth()))));
-		s.add(new DefaultMutableTreeNode(new KVP("CLUT_id", getCLUTId(), null)));
-		s.add(new DefaultMutableTreeNode(new KVP("region_8-bit_pixel_code", getRegion8BitPixelCode(), null)));
-		s.add(new DefaultMutableTreeNode(new KVP("region_4-bit_pixel-code", getRegion4BitPixelCode(), null)));
-		s.add(new DefaultMutableTreeNode(new KVP("region_2-bit_pixel-code", getRegion2BitPixelCode(), null)));
+		s.add(new KVP("region_id", getRegionId()));
+		s.add(new KVP("region_version_number", getRegionVersionNumber()));
+		s.add(new KVP("region_fill_flag", getRegionFillFlag()));
+		s.add(new KVP("region_width", getRegionWidth()));
+		s.add(new KVP("region_height", getRegionHeight()));
+		s.add(new KVP("region_level_of_compatibility", getRegionLevelOfCompatibility()).setDescription(getRegionLevelOfCompatibilityString(getRegionLevelOfCompatibility())));
+		s.add(new KVP("region_depth", getRegionDepth()).setDescription(getRegionDepthString(getRegionDepth())));
+		s.add(new KVP("CLUT_id", getCLUTId()));
+		s.add(new KVP("region_8-bit_pixel_code", getRegion8BitPixelCode()));
+		s.add(new KVP("region_4-bit_pixel-code", getRegion4BitPixelCode()));
+		s.add(new KVP("region_2-bit_pixel-code", getRegion2BitPixelCode()));
 
 		addListJTree(s, getRegionObjects(), modus, "regions");
 
 		return s;
 	}
 
-	/**
-	 * @return
-	 */
-	/**
-	 * @return
-	 */
+
 	public int getRegion2BitPixelCode() {
 		return getInt(data_block, offset + 15, 1, 0x0C) >> 2;
 	}
 
-	/**
-	 * @return
-	 */
-	/**
-	 * @return
-	 */
+
 	public int getRegion4BitPixelCode() {
 		return getInt(data_block, offset + 15, 1, 0xF0) >> 4;
 	}
 
-	/**
-	 * @return
-	 */
-	/**
-	 * @return
-	 */
+
 	public int getRegion8BitPixelCode() {
 		return getInt(data_block, offset + 14, 1, MASK_8BITS);
 	}
 
-	/**
-	 * @return
-	 */
-	/**
-	 * @return
-	 */
+
 	public int getCLUTId() {
 		return getInt(data_block, offset + 13, 1, MASK_8BITS);
 	}
 
-	/**
-	 * @return
-	 */
-	/**
-	 * @return
-	 */
+
 	public int getRegionHeight() {
 		return getInt(data_block, offset + 10, 2, MASK_16BITS);
 	}
 
-	/**
-	 * @return
-	 */
-	/**
-	 * @return
-	 */
+
 	public int getRegionWidth() {
 		return getInt(data_block, offset + 8, 2, MASK_16BITS);
 	}
 
-	/**
-	 * @return
-	 */
-	/**
-	 * @return
-	 */
+
 	public int getRegionFillFlag() {
 		return getInt(data_block, offset + 7, 1, 0x08) >> 3;
 	}
 
-	/**
-	 * @return
-	 */
-	/**
-	 * @return
-	 */
+
 	public int getRegionVersionNumber() {
 		return getInt(data_block, offset + 7, 1, 0xF0) >> 4;
 	}
 
-	/**
-	 * @return
-	 */
-	/**
-	 * @return
-	 */
+
 	public int getRegionId() {
 		return getInt(data_block, offset + 6, 1, MASK_8BITS);
 	}
@@ -322,7 +186,7 @@ public class RegionCompositionSegment extends Segment implements TreeNode {
 	 * @return
 	 */
 	public List<RegionObject> getRegionObjects() {
-		final ArrayList<RegionObject> regions = new ArrayList<RegionObject>();
+		final ArrayList<RegionObject> regions = new ArrayList<>();
 		int t = 0;
 		while ((t + 10) < getSegmentLength()) {
 			final int object_id = getInt(data_block, offset + 16 + t, 2, MASK_16BITS);
@@ -377,19 +241,13 @@ public class RegionCompositionSegment extends Segment implements TreeNode {
 	 */
 	public static String getRegionLevelOfCompatibilityString(final int type) {
 
-		switch (type) {
-
-		case 0x0:
-			return "reserved";
-		case 0x1:
-			return "2-bit/entry CLUT required";
-		case 0x2:
-			return "4-bit/entry CLUT required";
-		case 0x3:
-			return "8-bit/entry CLUT required";
-		default:
-			return "reserved";
-		}
+		return switch (type) {
+		case 0x0 -> "reserved";
+		case 0x1 -> "2-bit/entry CLUT required";
+		case 0x2 -> "4-bit/entry CLUT required";
+		case 0x3 -> "8-bit/entry CLUT required";
+		default -> "reserved";
+		};
 	}
 
 	/**
@@ -398,19 +256,13 @@ public class RegionCompositionSegment extends Segment implements TreeNode {
 	 */
 	public static String getRegionDepthString(final int type) {
 
-		switch (type) {
-
-		case 0x0:
-			return "reserved";
-		case 0x1:
-			return "2 bit";
-		case 0x2:
-			return "4 bit";
-		case 0x3:
-			return "8 bit";
-		default:
-			return "reserved";
-		}
+		return switch (type) {
+		case 0x0 -> "reserved";
+		case 0x1 -> "2 bit";
+		case 0x2 -> "4 bit";
+		case 0x3 -> "8 bit";
+		default -> "reserved";
+		};
 	}
 
 	/**
@@ -419,19 +271,13 @@ public class RegionCompositionSegment extends Segment implements TreeNode {
 	 */
 	public static String getObjectTypeString(final int type) {
 
-		switch (type) {
-
-		case 0x0:
-			return "basic_object, bitmap";
-		case 0x1:
-			return "basic_object, character";
-		case 0x2:
-			return "composite_object, string of characters";
-		case 0x3:
-			return "reserved";
-		default:
-			return "Illegal value";
-		}
+		return switch (type) {
+		case 0x0 -> "basic_object, bitmap";
+		case 0x1 -> "basic_object, character";
+		case 0x2 -> "composite_object, string of characters";
+		case 0x3 -> "reserved";
+		default -> "Illegal value";
+		};
 	}
 
 	/**
@@ -440,19 +286,13 @@ public class RegionCompositionSegment extends Segment implements TreeNode {
 	 */
 	public static String getObjectProviderString(final int type) {
 
-		switch (type) {
-
-		case 0x0:
-			return "provided in the subtitling stream";
-		case 0x1:
-			return "provided by a ROM in the IRD";
-		case 0x2:
-			return "Reserved";
-		case 0x3:
-			return "reserved";
-		default:
-			return "Illegal value";
-		}
+		return switch (type) {
+		case 0x0 -> "provided in the subtitling stream";
+		case 0x1 -> "provided by a ROM in the IRD";
+		case 0x2 -> "Reserved";
+		case 0x3 -> "reserved";
+		default -> "Illegal value";
+		};
 	}
 
 }

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/dvbsubtitling/RegionCompositionSegment.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/dvbsubtitling/RegionCompositionSegment.java
@@ -50,10 +50,10 @@ public class RegionCompositionSegment extends Segment {
 		private int background_pixel_code = 0;
 
 
-		public RegionObject(final int object_id, final int object_type,
-				final int object_provider_flag, final int object_horizontal_position,
-				final int object_vertical_position, final int foreground_pixel_code,
-				final int background_pixel_code) {
+		public RegionObject(int object_id, int object_type,
+                            int object_provider_flag, int object_horizontal_position,
+                            int object_vertical_position, int foreground_pixel_code,
+                            int background_pixel_code) {
 			this.object_id = object_id;
 			this.object_type = object_type;
 			this.object_provider_flag = object_provider_flag;
@@ -65,8 +65,8 @@ public class RegionCompositionSegment extends Segment {
 
 
 		@Override
-		public KVP getJTreeNode(final int modus) {
-			final KVP s = new KVP("Object");
+		public KVP getJTreeNode(int modus) {
+			KVP s = new KVP("Object");
 			s.add(new KVP("object_id", object_id));
 			s.add(new KVP("object_type", object_type).setDescription(getObjectTypeString(object_type)));
 			s.add(new KVP("object_provider_flag", object_provider_flag)
@@ -110,13 +110,13 @@ public class RegionCompositionSegment extends Segment {
 
 	}
 
-	public RegionCompositionSegment(final byte[] data, final int offset) {
+	public RegionCompositionSegment(byte[] data, int offset) {
 		super(data, offset);
 	}
 
 	@Override
-	public KVP getJTreeNode(final int modus) {
-		final KVP s = super.getJTreeNode(modus);
+	public KVP getJTreeNode(int modus) {
+		KVP s = super.getJTreeNode(modus);
 		s.add(new KVP("region_id", getRegionId()));
 		s.add(new KVP("region_version_number", getRegionVersionNumber()));
 		s.add(new KVP("region_fill_flag", getRegionFillFlag()));
@@ -179,23 +179,20 @@ public class RegionCompositionSegment extends Segment {
 		return getInt(data_block, offset + 6, 1, MASK_8BITS);
 	}
 
-	/**
-	 * @return
-	 */
-	/**
+    /**
 	 * @return
 	 */
 	public List<RegionObject> getRegionObjects() {
-		final ArrayList<RegionObject> regions = new ArrayList<>();
+		List<RegionObject> regions = new ArrayList<>();
 		int t = 0;
 		while ((t + 10) < getSegmentLength()) {
-			final int object_id = getInt(data_block, offset + 16 + t, 2, MASK_16BITS);
-			final int object_type = getInt(data_block, offset + 18 + t, 1, 0xC0) >> 6;
-		final int object_provider_flag = getInt(data_block, offset + 18 + t, 1,
+			int object_id = getInt(data_block, offset + 16 + t, 2, MASK_16BITS);
+			int object_type = getInt(data_block, offset + 18 + t, 1, 0xC0) >> 6;
+		int object_provider_flag = getInt(data_block, offset + 18 + t, 1,
 				0x30) >> 4;
-				final int object_horizontal_position = getInt(data_block,
+				int object_horizontal_position = getInt(data_block,
 						offset + 18 + t, 2, MASK_12BITS);
-				final int object_vertical_position = getInt(data_block, offset + 20 + t,
+				int object_vertical_position = getInt(data_block, offset + 20 + t,
 						2, MASK_12BITS);
 				int foreground_pixel_code = 0;
 				int background_pixel_code = 0;
@@ -215,20 +212,14 @@ public class RegionCompositionSegment extends Segment {
 		return regions;
 	}
 
-	/**
-	 * @return
-	 */
-	/**
+    /**
 	 * @return
 	 */
 	public int getRegionDepth() {
 		return getInt(data_block, offset + 12, 1, 0x1C) >> 2;
 	}
 
-	/**
-	 * @return
-	 */
-	/**
+    /**
 	 * @return
 	 */
 	public int getRegionLevelOfCompatibility() {
@@ -239,7 +230,7 @@ public class RegionCompositionSegment extends Segment {
 	 * @param type
 	 * @return
 	 */
-	public static String getRegionLevelOfCompatibilityString(final int type) {
+	public static String getRegionLevelOfCompatibilityString(int type) {
 
 		return switch (type) {
 		case 0x0 -> "reserved";
@@ -254,7 +245,7 @@ public class RegionCompositionSegment extends Segment {
 	 * @param type
 	 * @return
 	 */
-	public static String getRegionDepthString(final int type) {
+	public static String getRegionDepthString(int type) {
 
 		return switch (type) {
 		case 0x0 -> "reserved";
@@ -269,7 +260,7 @@ public class RegionCompositionSegment extends Segment {
 	 * @param type
 	 * @return
 	 */
-	public static String getObjectTypeString(final int type) {
+	public static String getObjectTypeString(int type) {
 
 		return switch (type) {
 		case 0x0 -> "basic_object, bitmap";
@@ -284,7 +275,7 @@ public class RegionCompositionSegment extends Segment {
 	 * @param type
 	 * @return
 	 */
-	public static String getObjectProviderString(final int type) {
+	public static String getObjectProviderString(int type) {
 
 		return switch (type) {
 		case 0x0 -> "provided in the subtitling stream";

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/dvbsubtitling/Segment.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/dvbsubtitling/Segment.java
@@ -50,21 +50,21 @@ public class Segment implements TreeNode{
 	}
 
 
-	private int getSegmentType(final int localOffset) {
+	private int getSegmentType(int localOffset) {
 
 		return getInt(data_block, offset+ localOffset, 1, MASK_8BITS);
 	}
 
 
-	public Segment(final byte[] data,final int offset) {
+	public Segment(byte[] data, int offset) {
 		data_block = data;
 		this.offset = offset;
 	}
 
 
 	@Override
-	public KVP getJTreeNode(final int modus) {
-		final KVP s=new KVP("Segment (" +DVBSubtitlingPESDataField.getSegmentTypeString(getSegmentType())+")");
+	public KVP getJTreeNode(int modus) {
+		KVP s=new KVP("Segment (" + getSegmentTypeString(getSegmentType())+")");
 		s.add(new KVP("raw_data",data_block,offset,getSegmentLength()+6));
 		s.add(new KVP("segment_type",getSegmentType()).setDescription(getSegmentTypeString(getSegmentType())));
 		s.add(new KVP("page_id",getPageID()));

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/dvbsubtitling/Segment.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/dvbsubtitling/Segment.java
@@ -2,7 +2,7 @@
  *
  *  http://www.digitalekabeltelevisie.nl/dvb_inspector
  *
- *  This code is Copyright 2009-2012 by Eric Berendsen (e_berendsen@digitalekabeltelevisie.nl)
+ *  This code is Copyright 2009-2024 by Eric Berendsen (e_berendsen@digitalekabeltelevisie.nl)
  *
  *  This file is part of DVB Inspector.
  *
@@ -27,13 +27,12 @@
 
 package nl.digitalekabeltelevisie.data.mpeg.pes.dvbsubtitling;
 
+import static nl.digitalekabeltelevisie.data.mpeg.pes.dvbsubtitling.DVBSubtitlingPESDataField.getSegmentTypeString;
 import static nl.digitalekabeltelevisie.util.Utils.*;
-
-import javax.swing.tree.DefaultMutableTreeNode;
 
 import nl.digitalekabeltelevisie.controller.KVP;
 import nl.digitalekabeltelevisie.controller.TreeNode;
-import nl.digitalekabeltelevisie.gui.ImageSource;
+
 
 /**
  * @author Eric Berendsen
@@ -41,65 +40,45 @@ import nl.digitalekabeltelevisie.gui.ImageSource;
  */
 public class Segment implements TreeNode{
 
-	/**
-	 *
-	 */
 	protected byte[] data_block;
 
-	/**
-	 *
-	 */
 	protected int offset;
 
-	/**
-	 * @return
-	 */
+
 	public int getSegmentType(){
 		return getSegmentType(1);
 	}
 
-	/**
-	 * @param localOffset
-	 * @return
-	 */
+
 	private int getSegmentType(final int localOffset) {
 
 		return getInt(data_block, offset+ localOffset, 1, MASK_8BITS);
 	}
 
-	/**
-	 * @param data
-	 * @param offset
-	 */
+
 	public Segment(final byte[] data,final int offset) {
 		data_block = data;
 		this.offset = offset;
 	}
 
-	/* (non-Javadoc)
-	 * @see nl.digitalekabeltelevisie.controller.TreeNode#getJTreeNode(int)
-	 */
+
+	@Override
 	public KVP getJTreeNode(final int modus) {
 		final KVP s=new KVP("Segment (" +DVBSubtitlingPESDataField.getSegmentTypeString(getSegmentType())+")");
-		s.add(new KVP("raw_data",data_block,offset,getSegmentLength()+6,null));
-		s.add(new KVP("segment_type",getSegmentType(),DVBSubtitlingPESDataField.getSegmentTypeString(getSegmentType())));
-		s.add(new KVP("page_id",getPageID(),null));
-		s.add(new KVP("segment_length",getSegmentLength(),null));
+		s.add(new KVP("raw_data",data_block,offset,getSegmentLength()+6));
+		s.add(new KVP("segment_type",getSegmentType()).setDescription(getSegmentTypeString(getSegmentType())));
+		s.add(new KVP("page_id",getPageID()));
+		s.add(new KVP("segment_length",getSegmentLength()));
 
 		return s;
 	}
 
 
-	/**
-	 * @return
-	 */
 	public int getPageID() {
 		return getInt(data_block, offset+2, 2, MASK_16BITS);
 	}
 
-	/**
-	 * @return
-	 */
+
 	public int getSegmentLength() {
 		return getInt(data_block, offset+4, 2, MASK_16BITS);
 	}

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/dvbsubtitling/Segment.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/dvbsubtitling/Segment.java
@@ -80,7 +80,7 @@ public class Segment implements TreeNode{
 	 * @see nl.digitalekabeltelevisie.controller.TreeNode#getJTreeNode(int)
 	 */
 	public DefaultMutableTreeNode getJTreeNode(final int modus, final ImageSource imgSource) {
-		final DefaultMutableTreeNode s=new DefaultMutableTreeNode(new KVP("Segment (" +DVBSubtitlingPESDataField.getSegmentTypeString(getSegmentType())+")", imgSource));
+		final DefaultMutableTreeNode s=new DefaultMutableTreeNode(new KVP("Segment (" +DVBSubtitlingPESDataField.getSegmentTypeString(getSegmentType())+")").addImageSource(imgSource, "Segment"));
 		s.add(new DefaultMutableTreeNode(new KVP("raw_data",data_block,offset,getSegmentLength()+6,null)));
 		s.add(new DefaultMutableTreeNode(new KVP("segment_type",getSegmentType(),DVBSubtitlingPESDataField.getSegmentTypeString(getSegmentType()))));
 		s.add(new DefaultMutableTreeNode(new KVP("page_id",getPageID(),null)));

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/dvbsubtitling/Segment.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/dvbsubtitling/Segment.java
@@ -79,20 +79,16 @@ public class Segment implements TreeNode{
 	/* (non-Javadoc)
 	 * @see nl.digitalekabeltelevisie.controller.TreeNode#getJTreeNode(int)
 	 */
-	public DefaultMutableTreeNode getJTreeNode(final int modus, final ImageSource imgSource) {
-		final DefaultMutableTreeNode s=new DefaultMutableTreeNode(new KVP("Segment (" +DVBSubtitlingPESDataField.getSegmentTypeString(getSegmentType())+")").addImageSource(imgSource, "Segment"));
-		s.add(new DefaultMutableTreeNode(new KVP("raw_data",data_block,offset,getSegmentLength()+6,null)));
-		s.add(new DefaultMutableTreeNode(new KVP("segment_type",getSegmentType(),DVBSubtitlingPESDataField.getSegmentTypeString(getSegmentType()))));
-		s.add(new DefaultMutableTreeNode(new KVP("page_id",getPageID(),null)));
-		s.add(new DefaultMutableTreeNode(new KVP("segment_length",getSegmentLength(),null)));
+	public KVP getJTreeNode(final int modus) {
+		final KVP s=new KVP("Segment (" +DVBSubtitlingPESDataField.getSegmentTypeString(getSegmentType())+")");
+		s.add(new KVP("raw_data",data_block,offset,getSegmentLength()+6,null));
+		s.add(new KVP("segment_type",getSegmentType(),DVBSubtitlingPESDataField.getSegmentTypeString(getSegmentType())));
+		s.add(new KVP("page_id",getPageID(),null));
+		s.add(new KVP("segment_length",getSegmentLength(),null));
 
 		return s;
 	}
 
-	public DefaultMutableTreeNode getJTreeNode(final int modus) {
-
-		return getJTreeNode(modus, null);
-	}
 
 	/**
 	 * @return

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/dvbsubtitling/Titles.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/dvbsubtitling/Titles.java
@@ -61,7 +61,7 @@ public class Titles implements TreeNode {
 				if(current!=null){
 					if(currentEpoch!=null){
 						currentEpoch.add(current);
-						current.setEpoch(new ArrayList<DisplaySet>(currentEpoch));
+						current.setEpoch(new ArrayList<>(currentEpoch));
 					}
 					displaySets.add(current);
 					current = null;
@@ -81,7 +81,7 @@ public class Titles implements TreeNode {
 					if(segment.getSegmentType()==0x80){ // end of display set segment
 						if(currentEpoch!=null){
 							currentEpoch.add(current);
-							current.setEpoch(new ArrayList<DisplaySet>(currentEpoch));
+							current.setEpoch(new ArrayList<>(currentEpoch));
 						}
 						displaySets.add(current);
 						current = null;

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/dvbsubtitling/Titles.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/dvbsubtitling/Titles.java
@@ -54,7 +54,6 @@ public class Titles implements TreeNode {
 
 	// TODO this does not correctly handle if the first PESpacket is not the start of a DisplaySegment
 
-	@SuppressWarnings("unchecked")
 	public void add(DVBSubtitlingPESDataField title) {
 		List<Segment> segmentList = title.getSegmentList();
 		if((segmentList!=null)&&(!segmentList.isEmpty())){
@@ -62,7 +61,7 @@ public class Titles implements TreeNode {
 				if(current!=null){
 					if(currentEpoch!=null){
 						currentEpoch.add(current);
-						current.setEpoch((ArrayList<DisplaySet>) currentEpoch.clone());
+						current.setEpoch(new ArrayList<DisplaySet>(currentEpoch));
 					}
 					displaySets.add(current);
 					current = null;
@@ -82,7 +81,7 @@ public class Titles implements TreeNode {
 					if(segment.getSegmentType()==0x80){ // end of display set segment
 						if(currentEpoch!=null){
 							currentEpoch.add(current);
-							current.setEpoch((ArrayList<DisplaySet>) currentEpoch.clone());
+							current.setEpoch(new ArrayList<DisplaySet>(currentEpoch));
 						}
 						displaySets.add(current);
 						current = null;

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/dvbsubtitling/Titles.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/dvbsubtitling/Titles.java
@@ -47,7 +47,7 @@ public class Titles implements TreeNode {
 
 	@Override
 	public KVP getJTreeNode(int modus) {
-		final KVP t = new KVP("Titles");
+		KVP t = new KVP("Titles");
 		addListJTree(t,displaySets,modus,"DisplaySets");
 		return t;
 	}
@@ -57,8 +57,8 @@ public class Titles implements TreeNode {
 	@SuppressWarnings("unchecked")
 	public void add(DVBSubtitlingPESDataField title) {
 		List<Segment> segmentList = title.getSegmentList();
-		if((segmentList!=null)&&(segmentList.size()>0)){
-			if(segmentList.get(0).getSegmentType()==0xFF){ //stuffing, may end current set
+		if((segmentList!=null)&&(!segmentList.isEmpty())){
+			if(segmentList.getFirst().getSegmentType()==0xFF){ //stuffing, may end current set
 				if(current!=null){
 					if(currentEpoch!=null){
 						currentEpoch.add(current);

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/dvbsubtitling/Titles.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/dvbsubtitling/Titles.java
@@ -1,3 +1,30 @@
+/**
+ *
+ *  http://www.digitalekabeltelevisie.nl/dvb_inspector
+ *
+ *  This code is Copyright 2009-2024 by Eric Berendsen (e_berendsen@digitalekabeltelevisie.nl)
+ *
+ *  This file is part of DVB Inspector.
+ *
+ *  DVB Inspector is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  DVB Inspector is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with DVB Inspector.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  The author requests that he be notified of any application, applet, or
+ *  other binary that makes use of this code, but that's more out of curiosity
+ *  than anything and is not required.
+ *
+ */
+
 package nl.digitalekabeltelevisie.data.mpeg.pes.dvbsubtitling;
 
 import static nl.digitalekabeltelevisie.util.Utils.addListJTree;
@@ -5,30 +32,28 @@ import static nl.digitalekabeltelevisie.util.Utils.addListJTree;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.swing.tree.DefaultMutableTreeNode;
-
 import nl.digitalekabeltelevisie.controller.KVP;
 import nl.digitalekabeltelevisie.controller.TreeNode;
 
 public class Titles implements TreeNode {
-	
+
 	// only store complete display Sets.
 	// Stuffing segments are not stored.
-	// a display set can span multiple PesPackets. 
-	
-	private List<DisplaySet> displaySets = new ArrayList<DisplaySet>();
+	// a display set can span multiple PesPackets.
+
+	private List<DisplaySet> displaySets = new ArrayList<>();
 	private DisplaySet current = null;
 	private ArrayList<DisplaySet> currentEpoch = null;
 
 	@Override
-	public DefaultMutableTreeNode getJTreeNode(int modus) {
-		final DefaultMutableTreeNode t=new DefaultMutableTreeNode(new KVP("Titles"));
-		addListJTree(t,displaySets,modus,"DisplaySets"); 
+	public KVP getJTreeNode(int modus) {
+		final KVP t = new KVP("Titles");
+		addListJTree(t,displaySets,modus,"DisplaySets");
 		return t;
 	}
 
 	// TODO this does not correctly handle if the first PESpacket is not the start of a DisplaySegment
-	
+
 	@SuppressWarnings("unchecked")
 	public void add(DVBSubtitlingPESDataField title) {
 		List<Segment> segmentList = title.getSegmentList();
@@ -48,11 +73,10 @@ public class Titles implements TreeNode {
 				}
 				for (Segment segment : segmentList) {
 					current.add(segment);
-					if(segment instanceof PageCompositionSegment){
-						PageCompositionSegment pageCompositionSegment = (PageCompositionSegment)segment;
+					if(segment instanceof PageCompositionSegment pageCompositionSegment){
 						if((pageCompositionSegment.getPageState()==0x1)
 							||(pageCompositionSegment.getPageState()==0x2)){
-							currentEpoch = new ArrayList<DisplaySet>();
+							currentEpoch = new ArrayList<>();
 						}
 					}
 					if(segment.getSegmentType()==0x80){ // end of display set segment

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/ebu/DRCSCharacter.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/ebu/DRCSCharacter.java
@@ -104,7 +104,7 @@ public class DRCSCharacter implements TreeNode, ImageSource {
 	 */
 	public DefaultMutableTreeNode getJTreeNode(final int modus) {
 
-		return new DefaultMutableTreeNode(new KVP("DRCS Character "+drcsNumber+", mode="+mode +" (" +getDRCSModeString(mode)+")",this));
+		return new DefaultMutableTreeNode(new KVP("DRCS Character "+drcsNumber+", mode="+mode +" (" +getDRCSModeString(mode)+")").addImageSource(this, "DRCS Character"));
 	}
 
 	/* (non-Javadoc)

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/ebu/Page.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/ebu/Page.java
@@ -92,7 +92,7 @@ public class Page implements TreeNode{
 						}
 					}
 
-					t.setUserObject(new KVP(titel.toString().trim(),subPage));
+					t.setUserObject(new KVP(titel.toString().trim()).addImageSource(subPage, titel.toString().trim()));
 					treeNode.add(t);
 				}
 			}

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/ebu/SubPage.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/ebu/SubPage.java
@@ -310,7 +310,7 @@ public class SubPage implements TreeNode, ImageSource, TextConstants, SaveAble{
 			if (pageLine != null) {
 				s.add(pageLine.getHTMLJTreeNode(modus));
 			} else {
-				s.add(new DefaultMutableTreeNode(new KVP(TxtDataField.BLACK_HTML_LINE, "")));
+				s.add(new DefaultMutableTreeNode(new KVP( "").setHtmlLabel(TxtDataField.BLACK_HTML_LINE)));
 			}
 		}
 		for (final TxtDataField txtDatafield : packetx_26) {

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/ebu/SubPage.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/ebu/SubPage.java
@@ -298,7 +298,7 @@ public class SubPage implements TreeNode, ImageSource, TextConstants, SaveAble{
 	}
 
 	public DefaultMutableTreeNode getJTreeNode(final int modus) {
-		final KVP kvp = new KVP("SubPage " + toHexString(subPageNo, 4), this);
+		final KVP kvp = new KVP("SubPage " + toHexString(subPageNo, 4)).addImageSource(this, "Sub Page");
 		final DefaultMutableTreeNode s = new DefaultMutableTreeNode(kvp);
 
 		final JMenuItem objectMenu = new JMenuItem("Save Page as .t42");

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/ebu/TxtDataField.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/ebu/TxtDataField.java
@@ -60,7 +60,7 @@ public class TxtDataField extends EBUDataField implements TreeNode{
 		super.addDetailsToJTree(s,modus);
 		addDetailsToJTree(s,modus);
 		if((getPacketNo()>=0)&&(getPacketNo()<=25)){
-			s.add(new DefaultMutableTreeNode(new KVP(getTeletextHTML(),getTeletextPlain())));
+			s.add(new DefaultMutableTreeNode(new KVP(getTeletextPlain()).setHtmlLabel(getTeletextHTML())));
 		}
 		return s;
 	}
@@ -156,7 +156,7 @@ public class TxtDataField extends EBUDataField implements TreeNode{
 	 * @return
 	 */
 	public List<TxtTriplet> getTxtTripletList() {
-		final ArrayList<TxtTriplet> tripletList = new ArrayList<TxtTriplet>();
+		final List<TxtTriplet> tripletList = new ArrayList<>();
 		for (int i = 1; i <= 13; i++) {
 			final TxtTriplet tr = new TxtTriplet(data_block,offset+4+(i*3));
 			tripletList.add(tr);
@@ -196,7 +196,7 @@ public class TxtDataField extends EBUDataField implements TreeNode{
 			final Triplet tr2 = tripletList.get(1);
 			final int secondCharset = (tr1.getVal()&0b11_1100_0000_0000_0000)>>14 | ((tr2.getVal() & 0b0111)<<4);
 			s.add(new DefaultMutableTreeNode(
-					new KVP("Second G0 Set Designation and National Option Selection",secondCharset,null)));;
+					new KVP("Second G0 Set Designation and National Option Selection",secondCharset,null)));
 			final int leftSidePanel = (tr2.getVal() & 0x08) >> 3;
 			final int rightSidePanel = (tr2.getVal() & 0x10) >> 4;
 			final int sidePanelStatusFlag = (tr2.getVal() & 0x20) >> 5;
@@ -241,10 +241,10 @@ public class TxtDataField extends EBUDataField implements TreeNode{
 
 				final String bgColor = "#" + Utils.toHexStringUnformatted(r_byte, 2)
 						+ Utils.toHexStringUnformatted(g_byte, 2) + Utils.toHexStringUnformatted(b_byte, 2);
-				final DefaultMutableTreeNode cmapEntry = new DefaultMutableTreeNode(new KVP(
+				final DefaultMutableTreeNode cmapEntry = new DefaultMutableTreeNode(new KVP("Colour Map entry " + i).setHtmlLabel(
 						"Colour Map entry " + i + " <code><span style=\"background-color: " + bgColor
-								+ "; color: white;\">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span></code>",
-						"Colour Map entry " + i));
+								+ "; color: white;\">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span></code>"
+						));
 				cmapEntry.add(new DefaultMutableTreeNode(new KVP("R", r, null)));
 				cmapEntry.add(new DefaultMutableTreeNode(new KVP("G", g, null)));
 				cmapEntry.add(new DefaultMutableTreeNode(new KVP("B", b, null)));
@@ -275,7 +275,7 @@ public class TxtDataField extends EBUDataField implements TreeNode{
 	 * @return
 	 */
 	protected List<Triplet> getTripletList() {
-		final ArrayList<Triplet> tripletList = new ArrayList<Triplet>();
+		final List<Triplet> tripletList = new ArrayList<>();
 		for (int i = 1; i <= 13; i++) {
 			final Triplet tr = new Triplet(data_block, offset + 4 + (i * 3));
 			tripletList.add(tr);
@@ -413,7 +413,7 @@ public class TxtDataField extends EBUDataField implements TreeNode{
 
 
 	public DefaultMutableTreeNode getHTMLJTreeNode(final int modus) {
-		final DefaultMutableTreeNode s=new DefaultMutableTreeNode(new KVP(getTeletextHTML(),getTeletextPlain()));
+		final DefaultMutableTreeNode s=new DefaultMutableTreeNode(new KVP(getTeletextPlain()).setHtmlLabel(getTeletextHTML()));
 		super.addDetailsToJTree(s, modus);
 		addDetailsToJTree(s,modus);
 		return s;

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/video/Video138182Handler.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/video/Video138182Handler.java
@@ -158,7 +158,7 @@ public class Video138182Handler extends VideoHandler implements ImageSource{
 	 * @see nl.digitalekabeltelevisie.data.mpeg.pes.GeneralPesHandler#getJTreeNode(int)
 	 */
 	public DefaultMutableTreeNode getJTreeNode(final int modus) {
-		final DefaultMutableTreeNode s=new DefaultMutableTreeNode(new KVP("13818-2 PES Data",this));
+		final DefaultMutableTreeNode s=new DefaultMutableTreeNode(new KVP("13818-2 PES Data").addImageSource(this, "Frames"));
 		addListJTree(s,pesPackets,modus,"PES Packets");
 		addCCDataToTree(modus, s);
 		

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/video/VideoPESDataField.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/video/VideoPESDataField.java
@@ -114,7 +114,7 @@ public class VideoPESDataField extends PesPacketData implements TreeNode, ImageS
 			}
 			type.append(")");
 		}
-		final DefaultMutableTreeNode s = super.getJTreeNode(modus,new KVP("Video PES Packet"+type,this));
+		final DefaultMutableTreeNode s = super.getJTreeNode(modus,new KVP("Video PES Packet"+type).addImageSource(this, "Frame"));
 		addListJTree(s,sections,modus,"Sections");
 		return s;
 	}

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/video/common/Construct.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/video/common/Construct.java
@@ -282,7 +282,9 @@ public class Construct implements TreeNode, HTMLSource{
 	 */
 	@Override
 	public DefaultMutableTreeNode getJTreeNode(final int modus) {
-		final DefaultMutableTreeNode t = new DefaultMutableTreeNode(new KVP("construct",this));
+		KVP kvp = new KVP("construct");
+		kvp.addHTMLSource(this, "Construct");
+		final DefaultMutableTreeNode t = new DefaultMutableTreeNode(kvp);
 		t.add(new DefaultMutableTreeNode(new KVP("one_bit",one_bit,"shall be '1' to maintain backwards compatibility with previous versions of CEA-708-C")));
 		t.add(new DefaultMutableTreeNode(new KVP("reserved",reserved,null)));
 		t.add(new DefaultMutableTreeNode(new KVP("cc_valid",cc_valid,cc_valid==1?"the two closed caption data bytes that follow are valid":"the two data bytes are invalid")));

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/video/jpegxs/JpegXsDataField.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/video/jpegxs/JpegXsDataField.java
@@ -49,7 +49,7 @@ public class JpegXsDataField extends PesPacketData {
     private final long color_primaries;
     private final long transfer_characteristics;
     private final long matrix_coefficients;
-    private final boolean video_full_range_flag;
+    private final int video_full_range_flag;
     private final long tcod;
 
     public JpegXsDataField(PesPacketData pesPacket) {
@@ -66,29 +66,29 @@ public class JpegXsDataField extends PesPacketData {
         color_primaries = reader.readBitsLong(8);
         transfer_characteristics = reader.readBitsLong(8);
         matrix_coefficients = reader.readBitsLong(8);
-        video_full_range_flag = reader.readBits(1) == 1;
+        video_full_range_flag = reader.readBits(1);
         reader.skiptoByteBoundary();
         tcod = reader.readBitsLong(4);
     }
 
     @Override
-    public DefaultMutableTreeNode getJTreeNode(final int modus) {
-        final DefaultMutableTreeNode jxes_node = new DefaultMutableTreeNode("JPEG-XS payload");
-        jxes_node.add(new DefaultMutableTreeNode(new KVP("JXES Length", jxes_length, null)));
-        jxes_node.add(new DefaultMutableTreeNode(new KVP("JXES Box Code", jxes_box_code, "\"jxes\"")));
-        jxes_node.add(new DefaultMutableTreeNode(new KVP("brat", brat, "Bit Rate (MBits/s)")));
-        jxes_node.add(JpegXsVideoDescriptor.buildFratNode(frat));
-        jxes_node.add(JpegXsVideoDescriptor.buildScharNode(schar));
-        jxes_node.add(JpegXsVideoDescriptor.buildPpihNode(ppih));
-        jxes_node.add(JpegXsVideoDescriptor.buildPlevNode(plev));
-        jxes_node.add(new DefaultMutableTreeNode(new KVP("colour_primaries", color_primaries, null)));
-        jxes_node.add(new DefaultMutableTreeNode(new KVP("transfer_characteristics", transfer_characteristics, null)));
-        jxes_node.add(new DefaultMutableTreeNode(new KVP("matrix_coefficients", matrix_coefficients, null)));
-        jxes_node.add(new DefaultMutableTreeNode(new KVP("video_full_range_flag", video_full_range_flag, null)));
-        jxes_node.add(new DefaultMutableTreeNode(new KVP("tcod", tcod, null)));
+	public DefaultMutableTreeNode getJTreeNode(final int modus) {
+		final KVP jxes_node = new KVP("JPEG-XS payload");
+		jxes_node.add(new KVP("JXES Length", jxes_length));
+		jxes_node.add(new KVP("JXES Box Code", jxes_box_code).setDescription("\"jxes\""));
+		jxes_node.add(new KVP("brat", brat, "Bit Rate (MBits/s)"));
+		jxes_node.add(JpegXsVideoDescriptor.buildFratNode(frat));
+		jxes_node.add(JpegXsVideoDescriptor.buildScharNode(schar));
+		jxes_node.add(JpegXsVideoDescriptor.buildPpihNode(ppih));
+		jxes_node.add(JpegXsVideoDescriptor.buildPlevNode(plev));
+		jxes_node.add(new KVP("colour_primaries", color_primaries));
+		jxes_node.add(new KVP("transfer_characteristics", transfer_characteristics));
+		jxes_node.add(new KVP("matrix_coefficients", matrix_coefficients));
+		jxes_node.add(new KVP("video_full_range_flag", video_full_range_flag));
+		jxes_node.add(new KVP("tcod", tcod));
 
-        final DefaultMutableTreeNode parent_node = super.getJTreeNode(modus, new KVP("JPEG-XS PES Packet"));
-        parent_node.add(jxes_node);
-        return parent_node;
-    }
+		final DefaultMutableTreeNode parent_node = super.getJTreeNode(modus, new KVP("JPEG-XS PES Packet"));
+		parent_node.add(jxes_node);
+		return parent_node;
+	}
 }

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/video264/Video14496Handler.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/video264/Video14496Handler.java
@@ -149,7 +149,7 @@ public class Video14496Handler extends H26xHandler<Video14496PESDataField, NALUn
 
 	@Override
 	public DefaultMutableTreeNode getJTreeNode(final int modus) {
-		final DefaultMutableTreeNode s=new DefaultMutableTreeNode(new KVP("H.264 PES Data",this));
+		final DefaultMutableTreeNode s=new DefaultMutableTreeNode(new KVP("H.264 PES Data").addImageSource(this, "Frames"));
 		addListJTree(s,pesPackets,modus,"PES Packets");
 		addCCDataToTree(modus, s);
 		

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/video265/H265Handler.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/video265/H265Handler.java
@@ -160,7 +160,7 @@ public class H265Handler extends H26xHandler<Video265PESDataField, H265NALUnit> 
 	 */
 	@Override
 	public DefaultMutableTreeNode getJTreeNode(final int modus) {
-		final DefaultMutableTreeNode s=new DefaultMutableTreeNode(new KVP("H.265 PES Data",this));
+		final DefaultMutableTreeNode s=new DefaultMutableTreeNode(new KVP("H.265 PES Data").addImageSource(this, "Frames"));
 		addListJTree(s,pesPackets,modus,"PES Packets");
 		addCCDataToTree(modus, s);
 

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/video266/H266Handler.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/pes/video266/H266Handler.java
@@ -83,7 +83,7 @@ public class H266Handler extends H26xHandler<Video266PESDataField, H266NALUnit> 
 	 * @see nl.digitalekabeltelevisie.data.mpeg.pes.GeneralPesHandler#getJTreeNode(int)
 	 */
 	public DefaultMutableTreeNode getJTreeNode(final int modus) {
-		final DefaultMutableTreeNode s = new DefaultMutableTreeNode(new KVP("H.266 PES Data", this));
+		final DefaultMutableTreeNode s=new DefaultMutableTreeNode(new KVP("H.266 PES Data").addImageSource(this, "Frames"));
 		addListJTree(s, pesPackets, modus, "PES Packets");
 		addCCDataToTree(modus, s);
 

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/psi/AITsection.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/psi/AITsection.java
@@ -83,7 +83,7 @@ public class AITsection extends TableSectionExtendedSyntax {
 				final List<ApplicationName> appNames = appNameDesc.getApplicationNames();
 				if((appNames!=null)&&(appNames.size()>0)){
 					final ApplicationName appName = appNames.get(0);
-					label.append(" (").append(appName.getApplication_name().toString()).append(")");
+					label.append(" (").append(appName.application_name().toString()).append(")");
 				}
 			}
 

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/psi/EITsection.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/psi/EITsection.java
@@ -300,9 +300,9 @@ public class EITsection extends TableSectionExtendedSyntax{
 					r1.append("<br><table>");
 					for(ExtendedEventDescriptor.Item item :extEvent.getItemList()){
 						r1.append("<tr><td>").
-							append(item.getItemDescription().toEscapedHTML()).
+							append(item.itemDescription().toEscapedHTML()).
 							append("</td><td>").
-							append(item.getItem().toEscapedHTML()).
+							append(item.item().toEscapedHTML()).
 							append("</td></tr>");
 					}
 					r1.append("</table>");

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/psi/EITsection.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/psi/EITsection.java
@@ -249,8 +249,8 @@ public class EITsection extends TableSectionExtendedSyntax{
 					List<ContentItem> contentList = contentDesc.getContentList();
 					for(ContentItem c:contentList){
 						r1.append("Content type: ").
-							append(ContentDescriptor.getContentNibbleLevel1String(c.getContentNibbleLevel1())).
-							append(ContentDescriptor.getContentNibbleLevel2String(c.getContentNibbleLevel1(),c.getContentNibbleLevel2())).
+							append(ContentDescriptor.getContentNibbleLevel1String(c.contentNibbleLevel1())).
+							append(ContentDescriptor.getContentNibbleLevel2String(c.contentNibbleLevel1(),c.contentNibbleLevel2())).
 							append("<br>");
 					}
 				}

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/psi/EITsection.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/psi/EITsection.java
@@ -26,8 +26,7 @@ package nl.digitalekabeltelevisie.data.mpeg.psi;
  *
  */
 
-import static nl.digitalekabeltelevisie.util.Utils.formatDuration;
-import static nl.digitalekabeltelevisie.util.Utils.getEscapedHTML;
+import static nl.digitalekabeltelevisie.util.Utils.*;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -98,7 +97,7 @@ public class EITsection extends TableSectionExtendedSyntax{
 			StringBuilder b = new StringBuilder("Event, ID=");
 			b.append(eventID).
 			append(", start_time:").
-			append(Utils.getEITStartTimeAsString(startTime)).
+			append(getEITStartTimeAsString(startTime)).
 			append(", duration:").
 			append(formatDuration(duration));
 			for (Descriptor d : descriptorList) {
@@ -122,18 +121,17 @@ public class EITsection extends TableSectionExtendedSyntax{
 
 		}
 		@Override
-		public DefaultMutableTreeNode getJTreeNode(int modus){
+		public KVP getJTreeNode(int modus){
 
-			KVP kvp = new KVP("event",eventID,Utils.getEITStartTimeAsString(startTime)+" "+getEventName());
-			kvp.addHTMLSource(this,"Event details");
-			DefaultMutableTreeNode t = new DefaultMutableTreeNode(kvp);
-
-			t.add(new DefaultMutableTreeNode(new KVP("event_id",eventID,null)));
-			t.add(new DefaultMutableTreeNode(new KVP("start_time",startTime,Utils.getEITStartTimeAsString(startTime))));
-			t.add(new DefaultMutableTreeNode(new KVP("duration",duration,formatDuration(duration))));
-			t.add(new DefaultMutableTreeNode(new KVP("running_status",runningStatus,getRunningStatusString(runningStatus))));
-			t.add(new DefaultMutableTreeNode(new KVP("free_CA_mode",freeCAMode,getFreeCAmodeString(freeCAMode))));
-			t.add(new DefaultMutableTreeNode(new KVP("descriptors_loop_length",descriptorsLoopLength,null)));
+			KVP t = new KVP("event",eventID).setDescription(getEITStartTimeAsString(startTime)+" "+getEventName());
+			t.addHTMLSource(this,"Event details");
+			
+			t.add(new KVP("event_id", eventID));
+			t.add(new KVP("start_time", startTime).setDescription(getEITStartTimeAsString(startTime)));
+			t.add(new KVP("duration", duration).setDescription(formatDuration(duration)));
+			t.add(new KVP("running_status", runningStatus).setDescription(getRunningStatusString(runningStatus)));
+			t.add(new KVP("free_CA_mode", freeCAMode).setDescription(getFreeCAmodeString(freeCAMode)));
+			t.add(new KVP("descriptors_loop_length", descriptorsLoopLength));
 
 			Utils.addListJTree(t,descriptorList,modus,"event_descriptors");
 
@@ -188,7 +186,7 @@ public class EITsection extends TableSectionExtendedSyntax{
 		public String getHTML() {
 			StringBuilder r1 = new StringBuilder();
 			r1.append("Start:&nbsp;").
-				append(Utils.getEITStartTimeAsString(getStartTime())).
+				append(getEITStartTimeAsString(getStartTime())).
 				append("&nbsp;Duration: ").
 				append(formatDuration(duration)).
 				append("<br><hr><br>");
@@ -338,10 +336,10 @@ public class EITsection extends TableSectionExtendedSyntax{
 	public EITsection(PsiSectionData raw_data, PID parent){
 		super(raw_data,parent);
 
-		transportStreamID = Utils.getInt(raw_data.getData(), 8, 2, Utils.MASK_16BITS);
-		originalNetworkID = Utils.getInt(raw_data.getData(), 10, 2, Utils.MASK_16BITS);
-		segmentLastSectionNumber= Utils.getInt(raw_data.getData(), 12, 1, Utils.MASK_8BITS);
-		lastTableID= Utils.getInt(raw_data.getData(), 13, 1, Utils.MASK_8BITS);
+		transportStreamID = getInt(raw_data.getData(), 8, 2, Utils.MASK_16BITS);
+		originalNetworkID = getInt(raw_data.getData(), 10, 2, Utils.MASK_16BITS);
+		segmentLastSectionNumber= getInt(raw_data.getData(), 12, 1, Utils.MASK_8BITS);
+		lastTableID= getInt(raw_data.getData(), 13, 1, Utils.MASK_8BITS);
 
 		eventList = buildEventList(raw_data.getData(), 14, sectionLength-14-4); //start and CRC(4)
 	}
@@ -385,17 +383,17 @@ public class EITsection extends TableSectionExtendedSyntax{
 
 	private List<Event> buildEventList(byte[] data, int offset, int programInfoLength) {
 		List<Event> r = new ArrayList<>();
-		int t =0;
-		while(t<programInfoLength){
+		int t = 0;
+		while (t < programInfoLength) {
 			Event c = new Event();
-			c.setEventID(Utils.getInt(data, offset+t, 2, Utils.MASK_16BITS));
-			c.setStartTime(Arrays.copyOfRange(data,offset+t+2,offset+t+7));
-			c.setDuration(Utils.getBCD(data, (offset+t+7)*2,6));
-			c.setRunningStatus(Utils.getInt(data, offset+t+10, 1, 0xE0)>>5);
-			c.setFreeCAMode(Utils.getInt(data, offset+t+10, 1, 0x10)>>4);
-			c.setDescriptorsLoopLength(Utils.getInt(data, offset+t+10, 2, Utils.MASK_12BITS));
-			c.setDescriptorList(DescriptorFactory.buildDescriptorList(data,offset+t+12,c.getDescriptorsLoopLength(),this));
-			t+=12+c.getDescriptorsLoopLength();
+			c.setEventID(getInt(data, offset + t, 2, Utils.MASK_16BITS));
+			c.setStartTime(Arrays.copyOfRange(data, offset + t + 2, offset + t + 7));
+			c.setDuration(getBCD(data, (offset + t + 7) * 2, 6));
+			c.setRunningStatus(getInt(data, offset + t + 10, 1, 0xE0) >> 5);
+			c.setFreeCAMode(getInt(data, offset + t + 10, 1, 0x10) >> 4);
+			c.setDescriptorsLoopLength(getInt(data, offset + t + 10, 2, Utils.MASK_12BITS));
+			c.setDescriptorList(DescriptorFactory.buildDescriptorList(data, offset + t + 12, c.getDescriptorsLoopLength(), this));
+			t += 12 + c.getDescriptorsLoopLength();
 			r.add(c);
 
 		}
@@ -411,11 +409,11 @@ public class EITsection extends TableSectionExtendedSyntax{
 		KVP kvp = (KVP)t.getUserObject();
 		kvp.addHTMLSource(()->getHtmlForEit(modus), "List");
 		kvp.addTableSource(this::getTableModel, "Events");
-		t.add(new DefaultMutableTreeNode(new KVP("service_id",getServiceID(),null)));
-		t.add(new DefaultMutableTreeNode(new KVP("transport_stream_id",transportStreamID,null)));
-		t.add(new DefaultMutableTreeNode(new KVP("original_network_id",originalNetworkID,Utils.getOriginalNetworkIDString(originalNetworkID))));
-		t.add(new DefaultMutableTreeNode(new KVP("segment_last_section_number",segmentLastSectionNumber,null)));
-		t.add(new DefaultMutableTreeNode(new KVP("last_table_id",lastTableID,null)));
+		t.add(new KVP("service_id",getServiceID()));
+		t.add(new KVP("transport_stream_id",transportStreamID));
+		t.add(new KVP("original_network_id",originalNetworkID).setDescription(Utils.getOriginalNetworkIDString(originalNetworkID)));
+		t.add(new KVP("segment_last_section_number",segmentLastSectionNumber));
+		t.add(new KVP("last_table_id",lastTableID));
 
 		Utils.addListJTree(t,eventList,modus,"events");
 
@@ -444,7 +442,7 @@ public class EITsection extends TableSectionExtendedSyntax{
 	public StringBuilder getHTMLLines(int modus){
 		StringBuilder b = new StringBuilder();
 		for(Event event:eventList){
-			b.append(Utils.escapeHTML(Utils.getEITStartTimeAsString(event.getStartTime()))).
+			b.append(Utils.escapeHTML(getEITStartTimeAsString(event.getStartTime()))).
 				append("&nbsp;").
 				append(formatDuration(event.getDuration())).
 				append("&nbsp;");

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/psi/RCTsection.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/psi/RCTsection.java
@@ -80,32 +80,12 @@ public class RCTsection extends TableSectionExtendedSyntax {
 
 	public class LinkInfo implements TreeNode {
 
-		public class PromotionalText implements TreeNode {
-
-			private final String iso639LanguageCode;
-			private final DVBString promotional_text;
-
-			/**
-			 * @param iso639LanguageCode
-			 * @param promotional_text
-			 */
-			private PromotionalText(String iso639LanguageCode,
-					DVBString promotional_text) {
-				super();
-				this.iso639LanguageCode = iso639LanguageCode;
-				this.promotional_text = promotional_text;
-			}
-
-			/* (non-Javadoc)
-			 * @see nl.digitalekabeltelevisie.controller.TreeNode#getJTreeNode(int)
-			 */
+		public record PromotionalText(String iso639LanguageCode, DVBString promotional_text) implements TreeNode {
 			@Override
-			public DefaultMutableTreeNode getJTreeNode(int modus) {
-				final DefaultMutableTreeNode t = new DefaultMutableTreeNode(new KVP("promotional_text"));
-				t.add(new DefaultMutableTreeNode(new KVP("ISO 639-2_language_code", iso639LanguageCode,null)));
-				t.add(new DefaultMutableTreeNode(new KVP("promotional_text_encoding",promotional_text.getEncodingString(),null)));
-				t.add(new DefaultMutableTreeNode(new KVP("promotional_text_length",promotional_text.getLength(),null)));
-				t.add(new DefaultMutableTreeNode(new KVP("promotional_text",promotional_text,null)));
+			public KVP getJTreeNode(int modus) {
+				final KVP t = new KVP("promotional_text");
+				t.add(new KVP("ISO 639-2_language_code", iso639LanguageCode));
+				t.add(new KVP("promotional_text",promotional_text));
 
 				return t;
 			}
@@ -166,22 +146,24 @@ public class RCTsection extends TableSectionExtendedSyntax {
 
 		}
 
-		public DefaultMutableTreeNode getJTreeNode(final int modus) {
-			final DefaultMutableTreeNode t = new DefaultMutableTreeNode(new KVP("link_info"));
-			t.add(new DefaultMutableTreeNode(new KVP("link_info_length", len,null)));
-			t.add(new DefaultMutableTreeNode(new KVP("link_type", link_type, link_type_list.get(link_type))));
-			t.add(new DefaultMutableTreeNode(new KVP("how_related_classification_scheme_id", how_related_classification_scheme_id, how_related_classification_scheme_id_list.get(how_related_classification_scheme_id))));
-			t.add(new DefaultMutableTreeNode(new KVP("term_id", term_id, null)));
-			t.add(new DefaultMutableTreeNode(new KVP("group_id", group_id, null)));
-			t.add(new DefaultMutableTreeNode(new KVP("precedence", precedence, null)));
-			t.add(new DefaultMutableTreeNode(new KVP("media_uri_length", media_uri_length, null)));
-			t.add(new DefaultMutableTreeNode(new KVP("media_uri_byte", media_uri_byte, null)));
-			t.add(new DefaultMutableTreeNode(new KVP("number_items", number_items, null)));
-			Utils.addListJTree(t,promotional_items,modus,"Promotional text Items");
-			t.add(new DefaultMutableTreeNode(new KVP("default_icon_flag", default_icon_flag, null)));
-			t.add(new DefaultMutableTreeNode(new KVP("icon_id", icon_id, null)));
-			t.add(new DefaultMutableTreeNode(new KVP("descriptor_loop_length", descriptor_loop_length, null)));
-			Utils.addListJTree(t,descriptor_loop,modus,"descriptor_loop");
+		@Override
+		public KVP getJTreeNode(final int modus) {
+			final KVP t = new KVP("link_info");
+			t.add(new KVP("link_info_length", len));
+			t.add(new KVP("link_type", link_type).setDescription(link_type_list.get(link_type)));
+			t.add(new KVP("how_related_classification_scheme_id", how_related_classification_scheme_id)
+					.setDescription(how_related_classification_scheme_id_list.get(how_related_classification_scheme_id)));
+			t.add(new KVP("term_id", term_id));
+			t.add(new KVP("group_id", group_id));
+			t.add(new KVP("precedence", precedence));
+			t.add(new KVP("media_uri_length", media_uri_length));
+			t.add(new KVP("media_uri_byte", media_uri_byte));
+			t.add(new KVP("number_items", number_items));
+			Utils.addListJTree(t, promotional_items, modus, "Promotional text Items");
+			t.add(new KVP("default_icon_flag", default_icon_flag));
+			t.add(new KVP("icon_id", icon_id));
+			t.add(new KVP("descriptor_loop_length", descriptor_loop_length));
+			Utils.addListJTree(t, descriptor_loop, modus, "descriptor_loop");
 
 			return t;
 		}
@@ -221,10 +203,10 @@ public class RCTsection extends TableSectionExtendedSyntax {
 	@Override
 	public DefaultMutableTreeNode getJTreeNode(final int modus) {
 		final DefaultMutableTreeNode t = super.getJTreeNode(modus);
-		t.add(new DefaultMutableTreeNode(new KVP("year_offset", year_offset, null)));
-		t.add(new DefaultMutableTreeNode(new KVP("link_count", link_count, null)));
+		t.add(new KVP("year_offset", year_offset));
+		t.add(new KVP("link_count", link_count));
 		Utils.addListJTree(t,links,modus,"link_infos");
-		t.add(new DefaultMutableTreeNode(new KVP("descriptor_loop_length", descriptor_loop_length, null)));
+		t.add(new KVP("descriptor_loop_length", descriptor_loop_length));
 		Utils.addListJTree(t,descriptor_loop,modus,"descriptor_loop");
 		return t;
 	}

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/psi/TableSection.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/psi/TableSection.java
@@ -378,7 +378,7 @@ public class TableSection implements TreeNode{
 
 	public DefaultMutableTreeNode getJTreeNode(final int modus){
 
-		final DefaultMutableTreeNode t = new DefaultMutableTreeNode(getSectionKVP(modus));
+		final KVP t = getSectionKVP(modus);
 		addTableDetails(modus, t);
 		return t;
 	}

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/psi/TableSection.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/psi/TableSection.java
@@ -399,41 +399,33 @@ public class TableSection implements TreeNode{
 
 	protected void addTableDetails(final int modus, final DefaultMutableTreeNode t) {
 		if (Utils.packetModus(modus)) {
-			t.add(new DefaultMutableTreeNode(new KVP("first_packet_no", firstPacketNo,
-					parentPID.getParentTransportStream().getPacketTime(firstPacketNo))));
-			t.add(new DefaultMutableTreeNode(new KVP("last_packet_no", lastPacketNo,
-					parentPID.getParentTransportStream().getPacketTime(lastPacketNo))));
-			t.add(new DefaultMutableTreeNode(new KVP("occurrence_count", occurrenceCount,
-					getRepetitionRate(occurrenceCount, lastPacketNo, firstPacketNo))));
+			t.add(new KVP("first_packet_no", firstPacketNo).setDescription(parentPID.getParentTransportStream().getPacketTime(firstPacketNo)));
+			t.add(new KVP("last_packet_no", lastPacketNo).setDescription(parentPID.getParentTransportStream().getPacketTime(lastPacketNo)));
+			t.add(new KVP("occurrence_count", occurrenceCount).setDescription(getRepetitionRate(occurrenceCount, lastPacketNo, firstPacketNo)));
 			if (occurrenceCount >= 2) {
 				if(getParentTransportStream().isAVCHD()) {
-					t.add(new DefaultMutableTreeNode(
-							new KVP("min_packet_distance in ticks", minPacketDistance, printPCRTime(minPacketDistance) )));
-					t.add(new DefaultMutableTreeNode(
-							new KVP("max_packet_distance in ticks", maxPacketDistance, printPCRTime(maxPacketDistance))));
+					t.add(new KVP("min_packet_distance in ticks", minPacketDistance).setDescription(printPCRTime(minPacketDistance)));
+					t.add(new KVP("max_packet_distance in ticks", maxPacketDistance).setDescription(printPCRTime(maxPacketDistance)));
 					
 				}else {
-					t.add(new DefaultMutableTreeNode(
-							new KVP("min_packet_distance in packets", minPacketDistance, getDistanceSecs(minPacketDistance))));
-					t.add(new DefaultMutableTreeNode(
-							new KVP("max_packet_distance in packets", maxPacketDistance, getDistanceSecs(maxPacketDistance))));
+					t.add(new KVP("min_packet_distance in packets", minPacketDistance).setDescription(getDistanceSecs(minPacketDistance)));
+					t.add(new KVP("max_packet_distance in packets", maxPacketDistance).setDescription(getDistanceSecs(maxPacketDistance)));
 				}
 			}
 		}
-		t.add(new DefaultMutableTreeNode(new KVP("table_id", tableId, getTableType(tableId))));
-		t.add(new DefaultMutableTreeNode(new KVP("section_syntax_indicator", sectionSyntaxIndicator, null)));
-		t.add(new DefaultMutableTreeNode(new KVP("private_indicator", privateIndicator, null)));
-		t.add(new DefaultMutableTreeNode(new KVP("section_length", sectionLength, null)));
+		t.add(new KVP("table_id", tableId, getTableType(tableId)));
+		t.add(new KVP("section_syntax_indicator", sectionSyntaxIndicator));
+		t.add(new KVP("private_indicator", privateIndicator));
+		t.add(new KVP("section_length", sectionLength));
 		if ((sectionSyntaxIndicator == 1)&&(tableId!=0x72)) { // long format, but not stuffing
-			t.add(new DefaultMutableTreeNode(new KVP(getTableIdExtensionLabel(), tableIdExtension, getTableIdExtensionDescription(tableIdExtension))));
-			t.add(new DefaultMutableTreeNode(new KVP("version", version, null)));
-			t.add(new DefaultMutableTreeNode(
-					new KVP("current_next_indicator", currentNext, (currentNext == 1) ? "current" : "next")));
-			t.add(new DefaultMutableTreeNode(new KVP("section_number", sectionNumber, null)));
-			t.add(new DefaultMutableTreeNode(new KVP("last_section_number", sectionLastNumber, null)));
-			t.add(new DefaultMutableTreeNode(new KVP("private_data", raw_data.getData(), 8, sectionLength - 5, null)));
+			t.add(new KVP(getTableIdExtensionLabel(), tableIdExtension).setDescription( getTableIdExtensionDescription(tableIdExtension)));
+			t.add(new KVP("version", version));
+			t.add(new KVP("current_next_indicator", currentNext).setDescription((currentNext == 1) ? "current" : "next"));
+			t.add(new KVP("section_number", sectionNumber));
+			t.add(new KVP("last_section_number", sectionLastNumber));
+			t.add(new KVP("private_data", raw_data.getData(), 8, sectionLength - 5));
 		} else {
-			t.add(new DefaultMutableTreeNode(new KVP("private_data", raw_data.getData(), 3, sectionLength, null)));
+			t.add(new KVP("private_data", raw_data.getData(), 3, sectionLength));
 		}
 	}
 

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/psi/nonstandard/M7Fastscan.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/psi/nonstandard/M7Fastscan.java
@@ -125,15 +125,15 @@ public class M7Fastscan implements TreeNode {
 			 LinkageDescriptor homeTP_location_descriptor = optionalHomeTP_location_descriptor.get();
 			 Optional<BrandHomeTransponder> optionalBrandHomeTransponder = homeTP_location_descriptor.getM7BrandHomeTransponderList()
 			 	.stream()
-			 	.filter(k -> k.getOperator_network_id() == operatorNetworkId)
-			 	.filter(k -> k.getFst_pid() == fstPid)
+			 	.filter(k -> k.operator_network_id() == operatorNetworkId)
+			 	.filter(k -> k.fst_pid() == fstPid)
 			 	.findFirst();
 			 
 
 			 
 			if (optionalBrandHomeTransponder.isPresent()) {
 				BrandHomeTransponder brandHomeTransponder = optionalBrandHomeTransponder.get();
-				int sublist_id = brandHomeTransponder.getOperator_sublist_id();
+				int sublist_id = brandHomeTransponder.operator_sublist_id();
 				r = "sublist_id: " + sublist_id;
 				if(ontSections!=null) {
 					for(ONTSection ontSection:ontSections) {

--- a/src/main/java/nl/digitalekabeltelevisie/gui/utils/GuiUtils.java
+++ b/src/main/java/nl/digitalekabeltelevisie/gui/utils/GuiUtils.java
@@ -77,11 +77,11 @@ public final class GuiUtils {
 	public static KVP getNotImplementedKVP(final String feature){
 		final StringBuilder message = new StringBuilder();
 		message.append(feature).append(" not implemented. ").append(getImproveMsg());
-		return new KVP("<span style=\"color: red;\">"+ message +"</span>",message.toString());
+		return new KVP(message.toString()).setHtmlLabel("<span style=\"color: red;\">"+ message +"</span>");
 	}
 
 	public static KVP getErrorKVP(final String message){
-		return new KVP("<span style=\"color: red;\">"+ message +"</span>", message);
+		return new KVP( message).setHtmlLabel("<span style=\"color: red;\">"+ message +"</span>");
 	}
 
 	public static String getImproveMsg() {

--- a/src/test/java/nl/digitalekabeltelevisie/controller/KVPTest.java
+++ b/src/test/java/nl/digitalekabeltelevisie/controller/KVPTest.java
@@ -114,7 +114,8 @@ public class KVPTest {
 
     @Test
     public void testHtmlLabelString() {
-        KVP kvp = new KVP("<h1>Head</h1>","<b>bold label?</b>");
+        //KVP kvp = new KVP("<h1>Head</h1>","<b>bold label?</b>");
+        KVP kvp = new KVP("<b>bold label?</b>").setHtmlLabel("<h1>Head</h1>");
         KVP.setStringDisplay(KVP.STRING_DISPLAY.HTML_AWT);
         assertEquals("<html><h1>Head</h1></html>",kvp.toString());
         KVP.setStringDisplay(KVP.STRING_DISPLAY.PLAIN);
@@ -122,7 +123,7 @@ public class KVPTest {
         KVP.setStringDisplay(KVP.STRING_DISPLAY.HTML_FRAGMENTS);
         assertEquals("<h1>Head</h1>",kvp.toString());
         KVP.setStringDisplay(KVP.STRING_DISPLAY.JAVASCRIPT);
-        assertEquals("",kvp.toString());
+        assertEquals("<h1>Head</h1>",kvp.toString());
     }
 
     @Test

--- a/src/test/java/nl/digitalekabeltelevisie/controller/KVPTest.java
+++ b/src/test/java/nl/digitalekabeltelevisie/controller/KVPTest.java
@@ -99,18 +99,6 @@ public class KVPTest {
         assertEquals("LabelForLong: 0x8E",kvp.toString());
     }
 
-    @Test
-    public void testKVPStringBooleanString() {
-        KVP kvp = new KVP("BooleanLabel",true,"Boooolean Explanation");
-        KVP.setNumberDisplay(KVP.NUMBER_DISPLAY.HEX);
-        assertEquals("BooleanLabel: 0x1 => Boooolean Explanation",kvp.toString());
-        KVP.setNumberDisplay(KVP.NUMBER_DISPLAY.BOTH);
-        assertEquals("BooleanLabel: 0x1 (1) => Boooolean Explanation",kvp.toString());
-        kvp = new KVP("BooleanLabel",false,"Boooolean false Explanation");
-        assertEquals("BooleanLabel: 0x0 (0) => Boooolean false Explanation",kvp.toString());
-        KVP.setNumberDisplay(KVP.NUMBER_DISPLAY.DECIMAL);
-        assertEquals("BooleanLabel: 0 => Boooolean false Explanation",kvp.toString());
-    }
 
     @Test
     public void testHtmlLabelString() {

--- a/src/test/java/nl/digitalekabeltelevisie/controller/KVPTest.java
+++ b/src/test/java/nl/digitalekabeltelevisie/controller/KVPTest.java
@@ -135,23 +135,62 @@ public class KVPTest {
 
 
     @Test
-    public void testKVPStringDVBStringString() {
+    public void testKVPStringDVBString() {
         final byte []rawString = {0x5,0x44,13,0x44,0x56,0x42,0x20,0x49,0x6e,0x73,0x70,0x65,0x63,0x74,0x6f,0x72,0x21,0x55};
         final byte []rawStringExtendedAsci = {0x5,0x44,5,-92,-68,-67,-66,-45};
 
+        byte[] realisateur = HexFormat.of().parseHex("0E10000252E9616C69736174657572"); 
 
         DVBString dvbString = new DVBString(rawString, 2);
 
-        KVP kvp = new KVP("DVBStringTest",dvbString,"description");
+        KVP kvp = new KVP("DVBStringTest",dvbString).setDescription("description");
 
         assertEquals("DVBStringTest: DVB Inspector => description", kvp.toString());
 
+        // two children, length and encoding
+        assertEquals(2, kvp.getChildCount());
+        assertTrue(kvp.getChildAt(0) instanceof KVP);
+        
+        assertEquals("encoding: default (ISO 6937, latin)", ((KVP)kvp.getChildAt(0)).toString());
+        assertEquals("length: 0xD (13)", ((KVP)kvp.getChildAt(1)).toString(KVP.STRING_DISPLAY.HTML_AWT, KVP.NUMBER_DISPLAY.BOTH));
+               
 
         dvbString = new DVBString(rawStringExtendedAsci, 2);
 
-        kvp = new KVP("quarter",dvbString,"half");
+        kvp = new KVP("quarter",dvbString).setDescription("half");
         assertEquals("quarter: €¼½¾© => half", kvp.toString());
+        
+        DVBString dvbStringRealisateur  = new DVBString(realisateur, 0);
+        kvp = new KVP("French",dvbStringRealisateur);
+        
+        assertEquals("French: Réalisateur", kvp.toString());
+
+        // two children, length and encoding
+        assertEquals(2, kvp.getChildCount());
+        assertTrue(kvp.getChildAt(0) instanceof KVP);
+        assertEquals("encoding: ISO/IEC 8859-2", ((KVP)kvp.getChildAt(0)).toString());
+        assertEquals("length: 14", ((KVP)kvp.getChildAt(1)).toString(KVP.STRING_DISPLAY.HTML_AWT, KVP.NUMBER_DISPLAY.DECIMAL));
+        
+		byte[] testHtml = HexFormat.of().parseHex("113c68313e263c62723e418A428643448744");
+		 
+		DVBString tst = new DVBString(testHtml,0);
+		kvp = new KVP("test html",tst);
+		
+		assertEquals("test html: <h1>&<br>ABCDD", kvp.toString());
+
+        assertEquals(2, kvp.getChildCount());
+        assertTrue(kvp.getChildAt(0) instanceof KVP);
+        assertEquals("encoding: default (ISO 6937, latin)", ((KVP)kvp.getChildAt(0)).toString());
+        assertEquals("length: 17", ((KVP)kvp.getChildAt(1)).toString(KVP.STRING_DISPLAY.HTML_AWT, KVP.NUMBER_DISPLAY.DECIMAL));
+        
+        assertEquals(1 ,kvp.getDetailViews().size());
+
+        assertEquals("DVB String",kvp.getDetailViews().getFirst().label());
+        assertTrue(kvp.getDetailViews().getFirst().detailSource()  instanceof HTMLSource);
+        
+        assertEquals("<b>Encoding:</b> default (ISO 6937, latin)<br><br><b>Data:</b><br><pre>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;0001 0203 0405 0607 0809 0A0B 0C0D 0E0F 0123456789ABCDEF<br>0x000000&nbsp;<span style=\"color:black; background-color: white;\">3C68&nbsp;313E&nbsp;263C&nbsp;6272&nbsp;3E41&nbsp;8A42&nbsp;8643&nbsp;4487&nbsp;&lt;h1&gt;&amp;&lt;br&gt;A.B.CD.</span><br>0x000010&nbsp;<span style=\"color:black; background-color: white;\">44&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;D</span><br></pre><br><b>Formatted:</b><br> &lt;h1&gt;&amp;&lt;br&gt;A<br> B<em> CD</em> D",((HTMLSource)kvp.getDetailViews().getFirst().detailSource()).getHTML()); 
     }
+    
 
     @Test
     public void testKVPStringHTMLSource() {

--- a/src/test/java/nl/digitalekabeltelevisie/controller/KVPTest.java
+++ b/src/test/java/nl/digitalekabeltelevisie/controller/KVPTest.java
@@ -55,11 +55,11 @@ public class KVPTest {
                 return null;
             }
         };
-        KVP kvp = new KVP("Plaatje", imgSource);
+        KVP kvp = new KVP("Plaatje").addImageSource(imgSource, "label3");
         assertEquals("Plaatje", kvp.toString());
         assertEquals(1, kvp.getDetailViews().size());
         assertEquals(imgSource, kvp.getDetailViews().getFirst().detailSource());
-        assertEquals("", kvp.getDetailViews().getFirst().label());
+        assertEquals("label3", kvp.getDetailViews().getFirst().label());
     }
 
     @Test
@@ -176,7 +176,8 @@ public class KVPTest {
                 return html;
             }
         };
-        KVP kvp = new KVP("htmlfragment",htmlSource);
+        KVP kvp = new KVP("htmlfragment");
+        kvp.addHTMLSource(htmlSource, "htmlfragment");
 
         kvp.appendLabel(" [1]");
         assertEquals("htmlfragment [1]",kvp.toString());


### PR DESCRIPTION
Made KVP extend DefaultMutableTreeNode, and cleaned up constructors and setters. From now on getJTreeNode should return KVPs. Not retrofitted it to all code (yet?), so interface TreeNode still has getJTreeNode(int modus) return a DefaultMutableTreeNode. 

All generated trees should be identical, except for KVP for DVB String. Now encoding and length are auto generated child nodes, no more need to explicit creating them. Als DVBString nodes now have auto HTMLSource, which displays raw bytes and formatted string.