### PR TITLE
Added SCTE35 TimeDescriptor, fixed segmentation descriptor without sub_segment_num and sub_segments_expected

### DIFF
--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/DescriptorFactory.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/DescriptorFactory.java
@@ -685,6 +685,8 @@ public final class DescriptorFactory {
 			return new AvailDescriptor(data, 0, tableSection);
 		case 0x02:
 			return new SegmentationDescriptor(data, 0, tableSection);
+        case 0x03:
+            return new TimeDescriptor(data, 0, tableSection);			
 		default:
 			Descriptor d = new SCTE35Descriptor(data, 0, tableSection);
 			logger.info("Not implemented SCTE35Descriptor:" + toUnsignedInt(data[0]) + " ("

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/scte35/SCTE35Descriptor.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/scte35/SCTE35Descriptor.java
@@ -65,7 +65,7 @@ public class SCTE35Descriptor extends Descriptor {
 		case 0x00: return "avail_descriptor"; 
 		case 0x01: return "DTMF_descriptor";
 		case 0x02: return "segmentation_descriptor"; 
-		case 0x03: return "DVB-time_descriptor";
+		case 0x03: return "time_descriptor";
 		case 0x04: return "audio_descriptor";
 		default:
 

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/scte35/SegmentationDescriptor.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/scte35/SegmentationDescriptor.java
@@ -184,10 +184,16 @@ public class SegmentationDescriptor extends SCTE35Descriptor {
 			segmentation_type_id  = getInt(b,localOffset++,1,MASK_8BITS);
 			segment_num = getInt(b,localOffset++,1,MASK_8BITS);
 			segments_expected = getInt(b,localOffset++,1,MASK_8BITS);
-			if(segmentation_type_id == 0x34 ||segmentation_type_id == 0x36) {
-				sub_segment_num = getInt(b,localOffset++,1,MASK_8BITS);
-				sub_segments_expected = getInt(b,localOffset++,1,MASK_8BITS);
-			}
+
+            //10.3.3.1. Segmentation descriptor details
+            // Note: sub_segment_num and sub_segments_expected can form an optional appendix to the segmentation descriptor.
+            // The presence or absence of this optional data block is determined by the descriptor loop’s descriptor_length.
+            if (((b.length -localOffset) >= 2   ) &&
+                    (segmentation_type_id == 0x34 || segmentation_type_id == 0x36 ||
+                            segmentation_type_id == 0x38 || segmentation_type_id == 0x3A)) {
+                sub_segment_num = getInt(b, localOffset++, 1, MASK_8BITS);
+                sub_segments_expected = getInt(b, localOffset++, 1, MASK_8BITS);
+            }
 		}
 	}
 

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/scte35/TimeDescriptor.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/scte35/TimeDescriptor.java
@@ -9,7 +9,6 @@ import static nl.digitalekabeltelevisie.util.Utils.*;
 
 public class TimeDescriptor extends SCTE35Descriptor {
 
-    private String identifier;
 	private long TAI_seconds;
     private long TAI_ns;
     private int UTC_offset;
@@ -28,8 +27,7 @@ public class TimeDescriptor extends SCTE35Descriptor {
 	
 	@Override
 	public DefaultMutableTreeNode getJTreeNode(final int modus){
-		final DefaultMutableTreeNode t = super.getJTreeNode(modus);
-		t.add(new DefaultMutableTreeNode(new KVP("identifier",identifier ,null)));
+		final DefaultMutableTreeNode t = super.getJTreeNode(modus);		
 		t.add(new DefaultMutableTreeNode(new KVP("TAI_seconds",TAI_seconds ,null)));
 		t.add(new DefaultMutableTreeNode(new KVP("TAI_ns",TAI_ns ,null)));
 		t.add(new DefaultMutableTreeNode(new KVP("UTC_offset",UTC_offset ,null)));

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/scte35/TimeDescriptor.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/scte35/TimeDescriptor.java
@@ -1,0 +1,39 @@
+package nl.digitalekabeltelevisie.data.mpeg.descriptors.scte35;
+
+import javax.swing.tree.DefaultMutableTreeNode;
+
+import nl.digitalekabeltelevisie.controller.KVP;
+import nl.digitalekabeltelevisie.data.mpeg.psi.TableSection;
+
+import static nl.digitalekabeltelevisie.util.Utils.*;
+
+public class TimeDescriptor extends SCTE35Descriptor {
+
+    private String identifier;
+	private long TAI_seconds;
+    private long TAI_ns;
+    private int UTC_offset;
+
+
+	public TimeDescriptor(byte[] b, int offset, TableSection parent) {
+		super(b, offset, parent);
+
+        identifier = getString(b,offset+2,4);
+        TAI_seconds = getLong(b,offset+6,6, 0xFFFFFFFFFFFFL);
+        TAI_ns = getLong(b,offset+12,4, 0xFFFFFFFFL);
+        UTC_offset = getInt(b,offset+16, 2, 0xFFFF);
+
+	}
+
+	
+	@Override
+	public DefaultMutableTreeNode getJTreeNode(final int modus){
+		final DefaultMutableTreeNode t = super.getJTreeNode(modus);
+		t.add(new DefaultMutableTreeNode(new KVP("identifier",identifier ,null)));
+		t.add(new DefaultMutableTreeNode(new KVP("TAI_seconds",TAI_seconds ,null)));
+		t.add(new DefaultMutableTreeNode(new KVP("TAI_ns",TAI_ns ,null)));
+		t.add(new DefaultMutableTreeNode(new KVP("UTC_offset",UTC_offset ,null)));
+		return t;
+	}
+
+}

--- a/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/scte35/TimeDescriptor.java
+++ b/src/main/java/nl/digitalekabeltelevisie/data/mpeg/descriptors/scte35/TimeDescriptor.java
@@ -9,16 +9,13 @@ import static nl.digitalekabeltelevisie.util.Utils.*;
 
 public class TimeDescriptor extends SCTE35Descriptor {
 
-    private String identifier;
 	private long TAI_seconds;
     private long TAI_ns;
     private int UTC_offset;
 
 
 	public TimeDescriptor(byte[] b, int offset, TableSection parent) {
-		super(b, offset, parent);
-
-        identifier = getString(b,offset+2,4);
+		super(b, offset, parent);        
         TAI_seconds = getLong(b,offset+6,6, 0xFFFFFFFFFFFFL);
         TAI_ns = getLong(b,offset+12,4, 0xFFFFFFFFL);
         UTC_offset = getInt(b,offset+16, 2, 0xFFFF);
@@ -28,8 +25,7 @@ public class TimeDescriptor extends SCTE35Descriptor {
 	
 	@Override
 	public DefaultMutableTreeNode getJTreeNode(final int modus){
-		final DefaultMutableTreeNode t = super.getJTreeNode(modus);
-		t.add(new DefaultMutableTreeNode(new KVP("identifier",identifier ,null)));
+		final DefaultMutableTreeNode t = super.getJTreeNode(modus);		
 		t.add(new DefaultMutableTreeNode(new KVP("TAI_seconds",TAI_seconds ,null)));
 		t.add(new DefaultMutableTreeNode(new KVP("TAI_ns",TAI_ns ,null)));
 		t.add(new DefaultMutableTreeNode(new KVP("UTC_offset",UTC_offset ,null)));


### PR DESCRIPTION
Hi,

I have found a bug in SCTE35, segmentation descriptor parser
It always expect to have sub_segment_num and sub_segments_expected. 

According to scte 35 - 2022b 10.3.3.1  
Note: sub_segment_num and sub_segments_expected can form an optional appendix to the segmentation descriptor. The presence or absence of this optional data block is determined by the descriptor loop’s descriptor_length.

I also found that you don't have time_descriptor for scte35, so I added one.

As attachment - the packet that gives the error

[NUT_scte35-test_packet.zip](https://github.com/user-attachments/files/22722378/NUT_scte35-test_packet.zip)
